### PR TITLE
chore(auth): when session is expired, removed it

### DIFF
--- a/src/domain/auth.service.ts
+++ b/src/domain/auth.service.ts
@@ -1,6 +1,7 @@
 import type AuthRepository from '@/domain/auth.repository.interface';
 import type EventBus from '@/domain/event-bus';
 import AuthCompletedEvent from './event-bus/events/AuthCompleted';
+import UnauthorizedError from './entities/errors/Unauthorized';
 
 /**
  * Business logic for Authentication
@@ -24,6 +25,17 @@ export default class AuthService {
       this.repository.restoreSession()
         .then((session) => {
           this.acceptSession(session.accessToken, session.refreshToken);
+        })
+        .catch((error) => {
+          if (error instanceof UnauthorizedError && error.message === 'Session is not valid') {
+            console.warn('❌ Auth session expired');
+
+            this.repository.removeSession();
+
+            return;
+          }
+
+          throw error;
         });
     }
   }

--- a/src/domain/auth.service.ts
+++ b/src/domain/auth.service.ts
@@ -30,7 +30,7 @@ export default class AuthService {
           if (error instanceof UnauthorizedError && error.message === 'Session is not valid') {
             console.warn('❌ Auth session expired');
 
-            this.repository.removeSession();
+            this.logout();
 
             return;
           }
@@ -58,5 +58,9 @@ export default class AuthService {
    */
   public async logout(): Promise<void> {
     await this.repository.removeSession();
+
+    /**
+     * @todo dispatch AuthLogoutEvent to notify all listeners about logout
+     */
   }
 }

--- a/src/infrastructure/auth.repository.ts
+++ b/src/infrastructure/auth.repository.ts
@@ -44,10 +44,10 @@ export default class AuthRepository implements AuthRepositoryInterface {
   public async removeSession(): Promise<void> {
     const refreshToken = this.authStorage.getRefreshToken();
 
-    const response = this.transport.delete('/auth', {
+    await this.transport.delete('/auth', {
       token: refreshToken,
     });
 
-    console.log('removeSession response', response);
+    this.authStorage.removeRefreshToken();
   }
 }

--- a/src/infrastructure/storage/auth.ts
+++ b/src/infrastructure/storage/auth.ts
@@ -29,4 +29,11 @@ export default class AuthStorage {
   public setRefreshToken(refreshToken: string): void {
     this.storage.setItem('refreshToken', refreshToken);
   }
+
+  /**
+   * Removes refresh token
+   */
+  public removeRefreshToken(): void {
+    this.storage.removeItem('refreshToken');
+  }
 }


### PR DESCRIPTION
### Problem:

If the refresh token is expired, we get `Unhandled Promise Rejection` during  the `restoreSession()` call.

<img width="834" alt="image" src="https://github.com/codex-team/notes.web/assets/3684889/267d9e53-abf5-47b2-9a1a-6b19e9815abb">

### Solution:

If we get the `Session is not valid` error during authorization, remove the invalid refresh token. Both form client store and API.