### PR TITLE
feat(note): create new note logic

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
     "jsdoc/check-tag-names": ["error", {
       "definedTags": ["template"]
     }],
-    "jsdoc/require-param-type": "off"
+    "jsdoc/require-param-type": "off",
+    "jsdoc/require-returns": "off"
   }
 }

--- a/src/application/router/routes.ts
+++ b/src/application/router/routes.ts
@@ -3,11 +3,12 @@ import Note from '@/presentation/pages/Note.vue';
 import Landing from '@/presentation/pages/Landing.vue';
 import Settings from '@/presentation/pages/Settings.vue';
 import NoteSettings from '@/presentation/pages/NoteSettings.vue';
+import type { RouteRecordRaw } from 'vue-router';
 
 // Default production hostname for homepage. If different, then custom hostname used
 const websiteHostname = import.meta.env.VITE_PRODUCTION_HOSTNAME;
 
-const routes = [
+const routes: RouteRecordRaw[] = [
   {
     name: 'home',
     path: '/',
@@ -22,7 +23,7 @@ const routes = [
     },
   },
   {
-    name: 'note_view',
+    name: 'note',
     path: '/note/:id',
     component: Note,
     props: route => ({

--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -5,12 +5,14 @@ import type { Note, NoteContent, NoteId } from '@/domain/entities/Note';
 import { useRouter } from 'vue-router';
 
 /**
- * Note Draft is a base structure for the empty note
+ * On new note creation, we use predefined structure of the Editor: header + paragraph
+ * We call it NoteDraft
  */
 type NoteDraft = Pick<Note, 'content'>;
 
 /**
- * Creates base structure for the empty note
+ * Creates base structure for the empty note:
+ * First block is Header, second is an empty Paragraph
  */
 function createDraft(): NoteDraft {
   return {

--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -1,33 +1,68 @@
-import { ref, type Ref } from 'vue';
-import type Note from '@/domain/entities/Note';
+import { onMounted, ref, type Ref, type MaybeRefOrGetter, computed, toValue, watch } from 'vue';
 import type NotesSettings from '@/domain/entities/NotesSettings';
 import { noteService } from '@/domain';
+import type { Note, NoteContent, NoteId } from '@/domain/entities/Note';
+import { useRouter } from 'vue-router';
+
+/**
+ * Note Draft is a base structure for the empty note
+ */
+type NoteDraft = Pick<Note, 'content'>;
+
+/**
+ * Creates base structure for the empty note
+ */
+function createDraft(): NoteDraft {
+  return {
+    content: {
+      blocks: [
+        {
+          type: 'header',
+          data: {
+            level: 1,
+            text: '',
+          },
+        },
+        {
+          type: 'paragraph',
+          data: {
+            text: '',
+          },
+        },
+      ],
+    },
+  };
+}
 
 /**
  * Note hook state
  */
 interface UseNoteComposableState {
   /**
-   * Note ref
+   * NoteDraft - on new note creation
+   * Note - when note is loaded
+   * null - when note is not loaded yet
    */
-  note: Ref<Note | null>;
+  note: Ref<Note | NoteDraft | null>;
+
+  /**
+   * Creates/updates the note
+   */
+  save: (content: NoteContent) => Promise<void>;
 
   /**
    * NoteSettings ref
+   *
+   * @todo move to the Note Settings service
    */
   noteSettings: Ref<NotesSettings | null>;
-
-  /**
-   * Load note
-   *
-   * @param publicId - note publicId
-   */
-  load: (publicId: string) => Promise<void>;
 
   /**
    * Load note settings
    *
    * @param publicId - note publicId
+   *
+   * @todo move to the Note Settings service
    */
   loadSettings: (publicId: string) => Promise<void>;
 
@@ -35,23 +70,32 @@ interface UseNoteComposableState {
    * Load note by custom hostname
    */
   resolveHostname: () => Promise<void>;
+}
 
+interface UseNoteComposableOptions {
   /**
-   * Is loading
+   * Note identifier
    */
-  isLoading: Ref<boolean>;
+  id: MaybeRefOrGetter<NoteId | null>;
 }
 
 /**
- * useNote hook
+ * Application service for working with the specific Note
  *
- * @returns { UseNoteComposableState } - Note hook state
+ * @param options - note service options
  */
-export default function (): UseNoteComposableState {
+export default function (options: UseNoteComposableOptions): UseNoteComposableState {
   /**
-   * Note ref
+   * Current note identifier
    */
-  const note = ref<Note | null>(null);
+  const currentId = computed(() => toValue(options.id));
+
+  /**
+   * Currently opened note
+   *
+   * When new note is created, fill with draft
+   */
+  const note = ref<Note | NoteDraft | null>(currentId.value === null ? createDraft() : null);
 
   /**
    * NoteSettings ref
@@ -59,48 +103,112 @@ export default function (): UseNoteComposableState {
   const noteSettings = ref<NotesSettings | null>(null);
 
   /**
-   * Is loading
+   * Router instance used to replace the current route with note id
    */
-  const isLoading = ref<boolean>(false);
+  const router = useRouter();
 
   /**
-   * Get note
+   * Load note by id
    *
-   * @param publicId - Note publicId
+   * @param id - Note identifier got from composable argument
    */
-  const load = async (publicId: string): Promise<void> => {
-    isLoading.value = true;
-    note.value = await noteService.getNoteById(publicId);
-    isLoading.value = false;
+  async function load(id: NoteId): Promise<void> {
+    /**
+     * @todo try-catch domain errors
+     */
+    note.value = await noteService.getNoteById(id);
   };
+
+  /**
+   * Saves the note
+   *
+   * @param content - Note content (Editor.js data)
+   */
+  async function save(content: NoteContent): Promise<void> {
+    if (note.value === null) {
+      throw new Error('Note is not loaded yet');
+    }
+
+    if (currentId.value === null) {
+      /**
+       * @todo try-catch domain errors
+       */
+      const noteCreated = await noteService.createNote(content);
+
+      /**
+       * Replace the current route with note id
+       */
+      router.replace({
+        name: 'note',
+        params: {
+          id: noteCreated.id,
+        },
+      });
+
+      return;
+    }
+
+    /**
+     * @todo update note
+     */
+    // await noteService.updateNoteContent(currentId.value, content);
+  }
 
   /**
    * Get note settings
    *
    * @param publicId - Note publicId
+   *
+   * @todo move to the Note Settings service
    */
   const loadSettings = async (publicId: string): Promise<void> => {
-    isLoading.value = true;
     noteSettings.value = await noteService.getNotesSettingsById(publicId);
-    isLoading.value = false;
   };
 
   /**
    * Get note by custom hostname
    */
   const resolveHostname = async (): Promise<void> => {
-    isLoading.value = true;
     note.value = await noteService.getNoteByHostname(location.hostname);
-    isLoading.value = false;
   };
+
+  onMounted(() => {
+    /**
+     * If we have id, load note
+     */
+    if (currentId.value !== null) {
+      load(currentId.value);
+    }
+  });
+
+  watch(currentId, (newId, prevId) => {
+    /**
+     * One note is open, user clicks on "+" to create another new note
+     * Clear existing note
+     */
+    if (newId === null) {
+      note.value = createDraft();
+
+      return;
+    }
+
+    /**
+     * Case for newly created note,
+     * we don't need to re-load it
+     */
+    if (prevId === null && newId !== null) {
+      return;
+    }
+
+    load(newId);
+  });
 
   return {
     note,
     noteSettings,
-    load,
     resolveHostname,
     loadSettings,
-    isLoading,
+    save,
   };
 }
 

--- a/src/domain/entities/Note.ts
+++ b/src/domain/entities/Note.ts
@@ -1,21 +1,26 @@
 import type { OutputData } from '@editorjs/editorjs';
 
 /**
+ * Note could be resolved by this id
+ */
+export type NoteId = string;
+
+/**
+ * The format we store a note content
+ */
+export type NoteContent = OutputData;
+
+/**
  * Note entity
  */
-export default interface Note {
+export interface Note {
   /**
-   * Note public id
+   * Note unique identifier visible to the user
    */
-  publicId: string;
-
-  /**
-   * Note title
-   */
-  title: string;
+  id: NoteId;
 
   /**
    * Note content
    */
-  content: OutputData;
+  content: NoteContent;
 }

--- a/src/domain/note.repository.interface.ts
+++ b/src/domain/note.repository.interface.ts
@@ -1,4 +1,4 @@
-import type Note from '@/domain/entities/Note';
+import type { Note, NoteContent } from '@/domain/entities/Note';
 import type NotesSettings from '@/domain/entities/NotesSettings';
 
 /**
@@ -11,8 +11,9 @@ export default interface NoteRepositoryInterface {
    *
    * @param publicId - Note id
    * @returns Note | null - Note instance
+   * @throws NotFoundError
    */
-  getNoteById(publicId: string): Promise<Note | null>;
+  getNoteById(publicId: string): Promise<Note>;
 
   /**
    * Returns a Note by hostname
@@ -21,6 +22,13 @@ export default interface NoteRepositoryInterface {
    * @returns Note | null - Note instance
    */
   getNoteByHostname(hostname: string): Promise<Note | null>;
+
+  /**
+   * Creates a new note
+   *
+   * @param content - Note content (Editor.js data)
+   */
+  createNote(content: NoteContent): Promise<Note>;
 
   /**
    * Returns NotesSettings by publicId

--- a/src/domain/note.service.ts
+++ b/src/domain/note.service.ts
@@ -51,17 +51,6 @@ export default class NoteService {
   }
 
   /**
-   * Updates a content of existing note
-   *
-   * @param publicId - Note publicId
-   * @param content - Note content (Editor.js data)
-   */
-  public async updateNoteContent(publicId: string, content: NoteContent): Promise<void> {
-    return await this.noteRepository.updateNoteContent(publicId, content);
-  }
-
-
-  /**
    * Get notesSettings
    *
    * @param publicId - Note publicId

--- a/src/domain/note.service.ts
+++ b/src/domain/note.service.ts
@@ -1,5 +1,5 @@
 import type NoteRepository from '@/domain/note.repository.interface';
-import type Note from '@/domain/entities/Note';
+import type { Note, NoteContent } from '@/domain/entities/Note';
 import type NotesSettings from '@/domain/entities/NotesSettings';
 
 /**
@@ -25,8 +25,9 @@ export default class NoteService {
    *
    * @param publicId - Note publicId
    * @returns { Note | null } - Note data
+   * @throws NotFoundError
    */
-  public async getNoteById(publicId: string): Promise<Note | null> {
+  public async getNoteById(publicId: string): Promise<Note> {
     return await this.noteRepository.getNoteById(publicId);
   }
 
@@ -41,21 +42,21 @@ export default class NoteService {
   }
 
   /**
-   * Updates a content of existing note
+   * Creates a new note and returns it
    *
-   * @param publicId - Note publicId
    * @param content - Note content (Editor.js data)
    */
-  public async updateNoteContent(publicId: string, content: NoteContent): Promise<void> {
-    return await this.noteRepository.updateNoteContent(publicId, content);
+  public async createNote(content: NoteContent): Promise<Note> {
+    return await this.noteRepository.createNote(content);
   }
-
 
   /**
    * Get notesSettings
    *
    * @param publicId - Note publicId
    * @returns { NotesSettings | null } - Note data
+   *
+   * @todo move to the Note Settings service
    */
   public async getNotesSettingsById(publicId: string): Promise<NotesSettings | null> {
     return await this.noteRepository.getNotesSettingsById(publicId);

--- a/src/domain/note.service.ts
+++ b/src/domain/note.service.ts
@@ -24,7 +24,7 @@ export default class NoteService {
    * Get note
    *
    * @param publicId - Note publicId
-   * @returns { Note | null } - Note data
+   * @returns Note data
    * @throws NotFoundError
    */
   public async getNoteById(publicId: string): Promise<Note> {

--- a/src/domain/note.service.ts
+++ b/src/domain/note.service.ts
@@ -51,6 +51,17 @@ export default class NoteService {
   }
 
   /**
+   * Updates a content of existing note
+   *
+   * @param publicId - Note publicId
+   * @param content - Note content (Editor.js data)
+   */
+  public async updateNoteContent(publicId: string, content: NoteContent): Promise<void> {
+    return await this.noteRepository.updateNoteContent(publicId, content);
+  }
+
+
+  /**
    * Get notesSettings
    *
    * @param publicId - Note publicId

--- a/src/domain/note.service.ts
+++ b/src/domain/note.service.ts
@@ -41,6 +41,17 @@ export default class NoteService {
   }
 
   /**
+   * Updates a content of existing note
+   *
+   * @param publicId - Note publicId
+   * @param content - Note content (Editor.js data)
+   */
+  public async updateNoteContent(publicId: string, content: NoteContent): Promise<void> {
+    return await this.noteRepository.updateNoteContent(publicId, content);
+  }
+
+
+  /**
    * Get notesSettings
    *
    * @param publicId - Note publicId

--- a/src/infrastructure/note.repository.ts
+++ b/src/infrastructure/note.repository.ts
@@ -131,4 +131,20 @@ export default class NoteRepository implements NoteRepositoryInterface {
 
     return notesSettings;
   }
+  /**
+   * Updates a content of existing note
+   *
+   * @param publicId - Note publicId
+   * @param content - Note content (Editor.js data)
+   */
+  public async updateNoteContent(publicId: string, content: Note['content']): Promise<void> {
+    await this.transport.patch('/note/' + publicId, {
+      content,
+    });
+
+    /**
+     * Insert note to storage
+     */
+    await this.noteStorage.updateNoteContent(publicId, content);
+  }
 }

--- a/src/infrastructure/note.repository.ts
+++ b/src/infrastructure/note.repository.ts
@@ -34,7 +34,7 @@ export default class NoteRepository implements NoteRepositoryInterface {
    * Get note by id
    *
    * @param id - Note identifier
-   * @returns { Note | null } - Note instance
+   * @returns Note instance
    * @throws NotFoundError
    */
   public async getNoteById(id: string): Promise<Note> {

--- a/src/infrastructure/storage/note.ts
+++ b/src/infrastructure/storage/note.ts
@@ -1,4 +1,4 @@
-import type Note from '@/domain/entities/Note';
+import type { Note } from '@/domain/entities/Note';
 import type NotesSettings from '@/domain/entities/NotesSettings';
 
 /**

--- a/src/infrastructure/transport/notes-api/types/GetNoteResponsePayload.ts
+++ b/src/infrastructure/transport/notes-api/types/GetNoteResponsePayload.ts
@@ -4,14 +4,9 @@ import type NotesSettings from '@/domain/entities/NotesSettings';
 /**
  * Get note response payload
  */
-type GetNoteResponsePayload = Note;
+export type GetNoteResponsePayload = Note;
 
 /**
  * Get notesSettings response payload
  */
-type GetNotesSettingsResponsePayload = NotesSettings;
-
-export type {
-  GetNoteResponsePayload,
-  GetNotesSettingsResponsePayload
-};
+export type GetNotesSettingsResponsePayload = NotesSettings;

--- a/src/presentation/components/editor/Editor.vue
+++ b/src/presentation/components/editor/Editor.vue
@@ -1,14 +1,12 @@
 <template>
-  <div id="editor" />
+  <div id="editorjs" />
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue';
-import Editor, { OutputData } from '@editorjs/editorjs';
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import Editor, { type OutputData, type API } from '@editorjs/editorjs';
 
-/**
- * Block Tools for the Editor
- */
+
 import Header from '@editorjs/header';
 import Image from '@editorjs/image';
 import CodeTool from '@editorjs/code';
@@ -20,27 +18,82 @@ import Checklist from '@editorjs/checklist';
 import LinkTool from '@editorjs/link';
 import RawTool from '@editorjs/raw';
 import Embed from '@editorjs/embed';
-
-/**
- * Inline Tools for the Editor
- */
 import InlineCode from '@editorjs/inline-code';
 import Marker from '@editorjs/marker';
+
 
 /**
  * Define the props for the component
  */
 const props = defineProps<{
-  data?: OutputData,
+  content?: OutputData,
 }>();
 
-onMounted(() => {
-  new Editor({
-    /**
-     * id of Element that should contain the Editor
-     */
-    holder: 'editor',
+const emit = defineEmits<{
+  'change': [data: OutputData],
+}>();
 
+/**
+ * Editor.js instance
+ */
+const editor = ref<Editor | undefined>(undefined);
+
+/**
+ * Attribute containing is-empty state.
+ * It is updated on every change of the editor
+ */
+const isEmpty = ref(true);
+
+/**
+ * Checks if the editor is empty
+ * Uses EditorJS API:
+ *  - blocks.getById()
+ *  - block.isEmpty()
+ *
+ * @todo implement "isEmpty" method in the EditorJS API
+ *
+ * @param data - saved data
+ * @param api - EditorJS API
+ */
+function checkIsEmpty(data: OutputData, api: API): boolean {
+  const blockIds = data.blocks.map((block) => block.id);
+
+  return blockIds.reduce((acc, id) => {
+    if (id === undefined) {
+      return acc;
+    }
+
+    const block = api.blocks.getById(id);
+
+    if (block) {
+      return acc && block.isEmpty;
+    }
+
+    return acc;
+  }, true);
+}
+
+/**
+ * Function called on every change of the editor
+ *
+ * @param api - EditorJS API
+ */
+async function onChange(api: API): Promise<void> {
+  const data = await api.saver.save();
+
+  /**
+   * Update the isEmpty attribute
+   */
+  isEmpty.value = checkIsEmpty(data, api);
+
+  /**
+   * Change model value
+   */
+  emit('change', data);
+}
+
+onMounted(async () => {
+  const editorInstance = new Editor({
     /**
      * Block Tools
      */
@@ -68,8 +121,39 @@ onMounted(() => {
       inlineCode: InlineCode,
       marker: Marker,
     },
-    data: props.data,
+    data: props.content,
+    onChange,
   });
+
+  await editorInstance.isReady;
+
+  editor.value = editorInstance;
+});
+
+watch(() => props.content, (content) => {
+  if (content === undefined) {
+    editor.value?.clear();
+
+    return;
+  }
+
+  if (editor.value) {
+    editor.value.render(content);
+  }
+});
+
+onBeforeUnmount(() => {
+  editor.value?.destroy();
+  editor.value = undefined;
+});
+
+defineExpose({
+  /**
+   * Returns the isEmpty attribute
+   */
+  isEmpty() {
+    return isEmpty.value;
+  },
 });
 </script>
 

--- a/src/presentation/components/header/Header.vue
+++ b/src/presentation/components/header/Header.vue
@@ -51,7 +51,7 @@ const tabs = computed<Tab[]>(() => {
   /**
    * Show inactive settings tab when we are on note view
    */
-  if ( currentRoute.value.name === 'note_view') {
+  if ( currentRoute.value.name === 'note') {
     availableTabs.push({
       title: t('home.settings'),
       path: currentRoute.value.path + '/settings',

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -8,9 +8,6 @@
     :content="note.content"
     @change="noteChanged"
   />
-  <pre>
-    {{ note }}
-  </pre>
 </template>
 
 <script lang="ts" setup>

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -1,19 +1,23 @@
 <template>
-  <Editor
-    :data="editorData"
-  />
-  <div v-if="id && isLoading">
+  <div v-if="note === null">
     Loading...
   </div>
-  <div v-if="id && !note">
-    Note not found
-  </div>
+  <Editor
+    v-else
+    ref="editor"
+    :content="note.content"
+    @change="noteChanged"
+  />
+  <pre>
+    {{ note }}
+  </pre>
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted } from 'vue';
+import { computed, ref } from 'vue';
 import Editor from '@/presentation/components/editor/Editor.vue';
 import useNote from '@/application/services/useNote';
+import { NoteContent } from '@/domain/entities/Note';
 
 const props = defineProps<{
   /**
@@ -22,48 +26,29 @@ const props = defineProps<{
   id: string | null;
 }>();
 
-const { note, load, isLoading } = useNote();
+const noteId = computed(() => props.id);
 
-onMounted(() => {
-  /**
-   * If we have id, load note
-   */
-  if (props.id !== null) {
-    load(props.id);
-  }
+const { note, save } = useNote({
+  id: noteId,
 });
 
 /**
- * Data will be used to create new note
+ * Editor component reference
  */
-const defaultData = {
-  blocks: [
-    {
-      type: 'header',
-      data: {
-        level: 1,
-        text: '',
-      },
-    },
-    {
-      type: 'paragraph',
-      data: {
-        text: '',
-      },
-    },
-  ],
-};
+const editor = ref<typeof Editor | undefined>(undefined);
 
 /**
- * Data do display in the editor
+ * Callback for editor change. Saves the note
+ *
+ * @param data - editor data
  */
-const editorData = computed(() => {
-  if (!note.value) {
-    return defaultData;
-  }
+function noteChanged(data: NoteContent): void {
+  const isEmpty = editor.value?.isEmpty();
 
-  return note.value.content;
-});
+  if (!isEmpty) {
+    save(data);
+  }
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
1. When user presses "+", open `/new` route with an empty Editor filled with draft structure (empty title + paragraph).
2. When user types some chars, create a new Note by API and change path to the `/note/<id>`
3. When user presses "+" from the `/note/<id>` page, open `/new` with empty editor again.

For now, only note creation is implemented. Note updating will be implemented in the next PRs.

https://github.com/codex-team/notes.web/assets/3684889/09fd2f62-eafc-44bf-85a6-9be2a236bd92

