### PR TITLE
fix(types): app state types improved

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "author": "CodeX <team@codex.so> (https://codex.so)",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite & yarn watch-ts",
     "build": "vue-tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext .ts,.vue",
-    "lint:fix": "yarn lint --fix"
+    "lint:fix": "yarn lint --fix",
+    "watch-ts": "vue-tsc --noEmit --watch"
   },
   "dependencies": {
     "@codexteam/icons": "^0.3.0",

--- a/src/application/services/useAppState.ts
+++ b/src/application/services/useAppState.ts
@@ -24,10 +24,8 @@ export const useAppState = createSharedComposable((): UseAppStateComposable => {
 
   /**
    * Subscribe to user changes in the App State
-   *
-   * @todo create better type definition for params
    */
-  AppStateController.user((prop: 'user', value: User) => {
+  AppStateController.user((prop: 'user', value: User | null) => {
     if (prop === 'user') {
       user.value = value;
     }

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -33,7 +33,8 @@ const userService = new UserService(eventBus, repositories.user);
  * Allows to subscribe to store data changes
  */
 export const AppStateController = {
-  user: (callback) => repositories.user.onStoreChange(callback),
+  // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+  user: (callback: Parameters<typeof repositories.user.setStoreChangeCallback>[0]) => repositories.user.setStoreChangeCallback(callback),
 };
 
 export {

--- a/src/infrastructure/repository.ts
+++ b/src/infrastructure/repository.ts
@@ -1,4 +1,4 @@
-import { SubscribableStore, type PropChangeCallback }  from './storage/abstract/subscribable';
+import { SubscribableStore, type PropChangeCallback } from './storage/abstract/subscribable';
 
 /**
  * Base class for repositories
@@ -17,7 +17,7 @@ export default abstract class Repository<Store, StoreData> {
    *
    * @param callback - callback that will be called on store change. Accepts new store data
    */
-  public onStoreChange(callback: PropChangeCallback<StoreData> ): void {
+  public setStoreChangeCallback(callback: PropChangeCallback<StoreData> ): void {
     if (this.store instanceof SubscribableStore) {
       this.store.subscribe(callback);
     } else {


### PR DESCRIPTION
This PR introduces two changes:

- setup TS type checking in dev mode which is [not included by default](https://vitejs.dev/guide/features.html#transpile-only)
- improve store-subscription method naming (`onStoreChange` -> `setStoreChangeCallback`)
- fix of the following error:

![image](https://github.com/codex-team/notes.web/assets/3684889/d66942e8-2fc4-4415-a8ed-35e96098781e)
