### PR TITLE
fix(ts): remaining ts errors fixed

### DIFF
--- a/src/domain/auth.service.ts
+++ b/src/domain/auth.service.ts
@@ -1,6 +1,6 @@
 import type AuthRepository from '@/domain/auth.repository.interface';
 import type EventBus from '@/domain/event-bus';
-import AuthCompletedEvent from './event-bus/events/AuthCompleted';
+import { AuthCompletedEvent } from './event-bus/events/AuthCompleted';
 import UnauthorizedError from './entities/errors/Unauthorized';
 
 /**

--- a/src/domain/event-bus/events/AuthCompleted.ts
+++ b/src/domain/event-bus/events/AuthCompleted.ts
@@ -8,7 +8,7 @@ export const AUTH_COMPLETED_EVENT_NAME = 'auth-completed';
 /**
  * Use cross domain events to explicitly implement side effects of changes within of a domain
  */
-export default class AuthCompletedEvent extends CustomEvent<AuthSession> {
+export class AuthCompletedEvent extends CustomEvent<AuthSession> {
   /**
    * Constructor options
    *

--- a/src/domain/event-bus/index.ts
+++ b/src/domain/event-bus/index.ts
@@ -1,6 +1,24 @@
+import type { AUTH_COMPLETED_EVENT_NAME, AuthCompletedEvent } from './events/AuthCompleted';
+
 /**
  * Event Bus provides a loosely coupled communication way between Domain and some other layers
  *
  * Extends native event emitter called EventTarget
  */
 export default class EventBus extends EventTarget {};
+
+/**
+ * All cross domain events map
+ */
+export type CrossDomainEventMap = {
+  [AUTH_COMPLETED_EVENT_NAME]: AuthCompletedEvent;
+};
+
+/**
+ * Augment EventTarget's addEventListener method to accept CustomEvent
+ */
+declare global {
+	interface EventTarget {
+    addEventListener<T extends keyof CrossDomainEventMap>(type: T, listener: (event: CrossDomainEventMap[T]) => void): void;
+	}
+}

--- a/src/infrastructure/index.ts
+++ b/src/infrastructure/index.ts
@@ -7,8 +7,7 @@ import AuthStore from '@/infrastructure/storage/auth';
 import UserRepository from '@/infrastructure/user.repository';
 import { UserStore } from '@/infrastructure/storage/user';
 import type EventBus from '@/domain/event-bus';
-import type AuthCompletedEvent from '@/domain/event-bus/events/AuthCompleted';
-import { AUTH_COMPLETED_EVENT_NAME } from '@/domain/event-bus/events/AuthCompleted';
+import { AUTH_COMPLETED_EVENT_NAME, type AuthCompletedEvent } from '@/domain/event-bus/events/AuthCompleted';
 
 /**
  * Repositories

--- a/src/presentation/components/editor/Editor.vue
+++ b/src/presentation/components/editor/Editor.vue
@@ -6,19 +6,31 @@
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import Editor, { type OutputData, type API } from '@editorjs/editorjs';
 
-
+// @ts-expect-error: we need to rewrite plugins to TS to get their types
 import Header from '@editorjs/header';
+// @ts-expect-error: we need to rewrite plugins to TS to get their types
 import Image from '@editorjs/image';
+// @ts-expect-error: we need to rewrite plugins to TS to get their types
 import CodeTool from '@editorjs/code';
+// @ts-expect-error: we need to rewrite plugins to TS to get their types
 import List from '@editorjs/list';
+// @ts-expect-error: we need to rewrite plugins to TS to get their types
 import Delimiter from '@editorjs/delimiter';
+// @ts-expect-error: we need to rewrite plugins to TS to get their types
 import Table from '@editorjs/table';
+// @ts-expect-error: we need to rewrite plugins to TS to get their types
 import Warning from '@editorjs/warning';
+// @ts-expect-error: we need to rewrite plugins to TS to get their types
 import Checklist from '@editorjs/checklist';
+// @ts-expect-error: we need to rewrite plugins to TS to get their types
 import LinkTool from '@editorjs/link';
+// @ts-expect-error: we need to rewrite plugins to TS to get their types
 import RawTool from '@editorjs/raw';
+// @ts-expect-error: we need to rewrite plugins to TS to get their types
 import Embed from '@editorjs/embed';
+// @ts-expect-error: we need to rewrite plugins to TS to get their types
 import InlineCode from '@editorjs/inline-code';
+// @ts-expect-error: we need to rewrite plugins to TS to get their types
 import Marker from '@editorjs/marker';
 
 

--- a/src/presentation/pages/Landing.vue
+++ b/src/presentation/pages/Landing.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div v-if="note">
+    <!-- <div v-if="note">
       <Editor :data="note.content" />
     </div>
     <div v-else-if="isLoading">
@@ -8,17 +8,23 @@
     </div>
     <div v-else>
       Note not found
-    </div>
+    </div> -->
   </div>
 </template>
 
 <script setup lang="ts">
-import Editor from '@/presentation/components/editor/Editor.vue';
-import useNote from '@/application/services/useNote';
+// import Editor from '@/presentation/components/editor/Editor.vue';
+// import useNote from '@/application/services/useNote';
 
-const { note, resolveHostname, isLoading } = useNote();
+/**
+ * @todo re-implement fetching note by hostname
+ * 1. Probably, it should use the same Note.vue component instead of Landing.vue
+ * 2. Probably, useNote() should accept not only id but also hostname as a parameter
+ * 3. Probably, you'll need to change onMounted() hook inside useNote() to make it work with the hostname as well
+ */
+// const { note, resolveHostname, isLoading } = useNote();
 
-resolveHostname();
+// resolveHostname();
 </script>
 
 <style lang="postcss" scoped>


### PR DESCRIPTION
This PR fixes all remaining TS errors.

- Event Bus types improved. Previously, `addEventListener` did not support `CustomEvents`. Now we have an `Event Map` and augmentation of `addEventListener` to respect it.
- Errors `Could not find a declaration file for module '@editorjs/...'` suppressed and waiting till we rewrite Editor Tools to TypeScript
- "Landing" page (Note-by-hostname feature) temporarily commented. It should be reimplemented