### PR TITLE
feat(transport): wait until auth finished, then send requests

### DIFF
--- a/src/domain/auth.service.ts
+++ b/src/domain/auth.service.ts
@@ -37,6 +37,8 @@ export default class AuthService {
 
           throw error;
         });
+    } else {
+      this.continueAnonymousSession();
     }
   }
 
@@ -62,5 +64,14 @@ export default class AuthService {
     /**
      * @todo dispatch AuthLogoutEvent to notify all listeners about logout
      */
+  }
+
+  /**
+   * We know that current user is not authorized.
+   *
+   * Tells the app to continue working in anonymous mode
+   */
+  private continueAnonymousSession(): void {
+    this.eventBus.dispatchEvent(new AuthCompletedEvent(null));
   }
 }

--- a/src/domain/event-bus/events/AuthCompleted.ts
+++ b/src/domain/event-bus/events/AuthCompleted.ts
@@ -8,13 +8,13 @@ export const AUTH_COMPLETED_EVENT_NAME = 'auth-completed';
 /**
  * Use cross domain events to explicitly implement side effects of changes within of a domain
  */
-export class AuthCompletedEvent extends CustomEvent<AuthSession> {
+export class AuthCompletedEvent extends CustomEvent<AuthSession | null> {
   /**
    * Constructor options
    *
-   * @param payload - data to send with event
+   * @param payload - Auth session if user is authorized or null if not
    */
-  constructor(payload: AuthSession) {
+  constructor(payload: AuthSession | null) {
     super(AUTH_COMPLETED_EVENT_NAME, {
       detail: payload,
     });

--- a/src/infrastructure/auth.repository.ts
+++ b/src/infrastructure/auth.repository.ts
@@ -35,6 +35,8 @@ export default class AuthRepository implements AuthRepositoryInterface {
   public async restoreSession(): Promise<AuthSession> {
     return this.transport.post<AuthSession>('/auth', {
       token: this.authStorage.getRefreshToken(),
+    }, {
+      skipAuthCheck: true,
     });
   }
 

--- a/src/infrastructure/index.ts
+++ b/src/infrastructure/index.ts
@@ -57,15 +57,22 @@ export function init(noteApiUrl: string, eventBus: EventBus): Repositories {
    * When we got authorized
    */
   eventBus.addEventListener(AUTH_COMPLETED_EVENT_NAME, (event: AuthCompletedEvent) => {
-    /**
-     * Authorize API transport
-     */
-    notesApiTransport.authorize(event.detail.accessToken);
+    if (event.detail !== null) {
+      /**
+       * Authorize API transport
+       */
+      notesApiTransport.authorize(event.detail.accessToken);
 
-    /**
-     * Save refresh token
-     */
-    authStore.setRefreshToken(event.detail.refreshToken);
+      /**
+       * Save refresh token
+       */
+      authStore.setRefreshToken(event.detail.refreshToken);
+    } else {
+      /**
+       * Tell API transport to continue working in anonymous mode (send waiting requests without auth)
+       */
+      notesApiTransport.continueAnonymous();
+    }
   });
 
   /**

--- a/src/infrastructure/transport/authorizable.transport.ts
+++ b/src/infrastructure/transport/authorizable.transport.ts
@@ -1,5 +1,6 @@
 import Transport from '@/infrastructure/transport';
 import type { FetchTransportOptions } from './fetch.transport';
+import type JSONValue from './types/JSONValue';
 
 /**
  * Additional options for authorizable transport
@@ -7,9 +8,36 @@ import type { FetchTransportOptions } from './fetch.transport';
 export interface AuthorizableTransportOptions extends FetchTransportOptions {}
 
 /**
+ * Additional params that could be specified for request
+ */
+export interface AuthorizableRequestParams {
+  /**
+   * If true, we don't need to wait for authorization for this request.
+   * For example, used for authorization requests itself
+   */
+  skipAuthCheck?: boolean;
+}
+
+/**
  * Transport with authorization, requires access token
  */
 export default class AuthorizableTransport extends Transport {
+  /**
+   * Current authorization status.
+   *
+   * Unknown - when authorization process is not finished yet
+   * Authorized - we are authorized, access token is set
+   * Unauthorized - we are not authorized, access token is not set
+   */
+  private authState: 'unknown' | 'authorized' | 'unauthorized' = 'unknown';
+
+  /**
+   * Queue of requests waiting for authorization
+   *
+   * Used when some request is made before authorization completed
+   */
+  private waitingAuthRequests: Array<() => void> = [];
+
   /**
    * Constructor for notes api transport
    *
@@ -27,5 +55,119 @@ export default class AuthorizableTransport extends Transport {
    */
   public authorize(accessToken: string): void {
     this.headers.set('Authorization', `Bearer ${accessToken}`);
+
+    this.authState = 'authorized';
+
+    this.onAuthFinished();
+  }
+
+  /**
+   * Continue anonymous session. All request will be made without authorization header
+   */
+  public continueAnonymous(): void {
+    this.authState = 'unauthorized';
+
+    this.onAuthFinished();
+  }
+
+  /**
+   * Gets specific resource
+   *
+   * @param endpoint - API endpoint
+   * @param data - data to be sent url encoded
+   * @param params - Additional params to tune request
+   */
+  public async get(endpoint: string, data?: JSONValue, params?: AuthorizableRequestParams): Promise<JSONValue> {
+    await this.waitForAuth(params);
+
+    return super.get(endpoint, data);
+  }
+
+
+  /**
+   * Make POST request to update some resource
+   *
+   * @param endpoint - API endpoint
+   * @param payload - JSON POST data body
+   * @param params - Additional params to tune request
+   */
+  public async post(endpoint: string, payload?: JSONValue, params?: AuthorizableRequestParams): Promise<JSONValue> {
+    await this.waitForAuth(params);
+
+    return super.post(endpoint, payload);
+  }
+
+  /**
+   * Make DELETE request to remove some resource
+   *
+   * @param endpoint - API endpoint
+   * @param payload - JSON POST data body
+   * @param params - Additional params to tune request
+   */
+  public async delete(endpoint: string, payload?: JSONValue, params?: AuthorizableRequestParams): Promise<JSONValue> {
+    await this.waitForAuth(params);
+
+    return super.delete(endpoint, payload);
+  }
+
+  /**
+   * Make PATCH request to update some resource
+   *
+   * @param endpoint - API endpoint
+   * @param payload - JSON POST data body
+   * @param params - Additional params to tune request
+   */
+  public async patch(endpoint: string, payload?: JSONValue, params?: AuthorizableRequestParams): Promise<JSONValue> {
+    await this.waitForAuth(params);
+
+    return super.patch(endpoint, payload);
+  }
+
+  /**
+   * If authorization process is not finished yet, enqueue request and wait for authorization
+   *
+   * @param params - Additional params passed to tune request
+   */
+  private async waitForAuth(params?: AuthorizableRequestParams): Promise<void> {
+    /**
+     * If the request as marked as "skip auth check", we don't need to wait for auth
+     */
+    if (params?.skipAuthCheck === true) {
+      return;
+    }
+
+    if (this.authState === 'unknown') {
+      console.groupCollapsed('✋ Request enqueued util auth finished');
+      console.trace();
+      console.groupEnd();
+
+      await new Promise((resolve) => {
+        this.waitingAuthRequests.push(() => {
+          resolve(undefined);
+        });
+      });
+    }
+  }
+
+  /**
+   * Called when auth process is finished. Now we know whether we are authorized or not.
+   *
+   * Sends enqueued requests
+   */
+  private onAuthFinished(): void {
+    if (this.waitingAuthRequests.length === 0) {
+      return;
+    }
+
+    console.groupCollapsed(`🤙 Auth finished, sending ${this.waitingAuthRequests.length} request(s) from queue...`);
+
+    this.waitingAuthRequests.forEach((request) => {
+      console.trace();
+      request();
+    });
+
+    console.groupEnd();
+
+    this.waitingAuthRequests = [];
   }
 }

--- a/src/infrastructure/transport/notes-api/index.ts
+++ b/src/infrastructure/transport/notes-api/index.ts
@@ -1,9 +1,15 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 import type { ApiErrorResponse } from '@/infrastructure/transport/notes-api/types/ApiResponse';
+import type { AuthorizableRequestParams } from '@/infrastructure/transport/authorizable.transport';
 import AuthorizableTransport from '@/infrastructure/transport/authorizable.transport';
 import type JSONValue from '../types/JSONValue';
 import UnauthorizedError from '@/domain/entities/errors/Unauthorized';
 import NotFoundError from '@/domain/entities/errors/NotFound';
+
+/**
+ * Additional params that could be specified for request to NoteX API
+ */
+interface NotexApiTransportRequestParams extends AuthorizableRequestParams {}
 
 /**
  * Notes api transport
@@ -59,9 +65,10 @@ export default class NotesApiTransport extends AuthorizableTransport {
    *
    * @param endpoint - API endpoint
    * @param data - data to be sent url encoded
+   * @param params - Additional params to tune request
    */
-  public async get<Payload>(endpoint: string, data?: JSONValue): Promise<Payload> {
-    const response = await super.get(endpoint, data);
+  public async get<Payload>(endpoint: string, data?: JSONValue, params?: NotexApiTransportRequestParams): Promise<Payload> {
+    const response = await super.get(endpoint, data, params);
 
     return response as Payload;
   }
@@ -71,9 +78,10 @@ export default class NotesApiTransport extends AuthorizableTransport {
    *
    * @param endpoint - API endpoint
    * @param data - data to be sent with request body
+   * @param params - Additional params to tune request
    */
-  public async post<Payload>(endpoint: string, data?: JSONValue): Promise<Payload> {
-    const response = await super.post(endpoint, data);
+  public async post<Payload>(endpoint: string, data?: JSONValue, params?: NotexApiTransportRequestParams): Promise<Payload> {
+    const response = await super.post(endpoint, data, params);
 
     return response as Payload;
   }
@@ -83,9 +91,10 @@ export default class NotesApiTransport extends AuthorizableTransport {
    *
    * @param endpoint - API endpoint
    * @param data - data to be sent with request body
+   * @param params - Additional params to tune request
    */
-  public async delete<Payload>(endpoint: string, data?: JSONValue): Promise<Payload> {
-    const response = await super.delete(endpoint, data);
+  public async delete<Payload>(endpoint: string, data?: JSONValue, params?: NotexApiTransportRequestParams): Promise<Payload> {
+    const response = await super.delete(endpoint, data, params);
 
     return response as Payload;
   }
@@ -95,9 +104,10 @@ export default class NotesApiTransport extends AuthorizableTransport {
    *
    * @param endpoint - API endpoint
    * @param data - data to be sent with request body
+   * @param params - Additional params to tune request
    */
-  public async patch<Payload>(endpoint: string, data?: JSONValue): Promise<Payload> {
-    const response = await super.patch(endpoint, data);
+  public async patch<Payload>(endpoint: string, data?: JSONValue, params?: NotexApiTransportRequestParams): Promise<Payload> {
+    const response = await super.patch(endpoint, data, params);
 
     return response as Payload;
   }


### PR DESCRIPTION
## Problem

Authorization request and other requests (e.g `GET /note/<id>`) goes in parallel. So some requests could be send without Authorisation header because Auth is not finished.

## Solution

If auth is not finished, enqueue request. When auth is finished, send enqueued request.

![image](https://github.com/codex-team/notes.web/assets/3684889/a9a8f3d1-b5ff-46e0-ba2b-e4adadc62870)
