### PR TITLE
fix: header & homepage i18n

### DIFF
--- a/src/application/i18n/messages/en.json
+++ b/src/application/i18n/messages/en.json
@@ -6,9 +6,14 @@
     "title": "Settings",
     "changeTheme": "Change theme"
   },
+  "header": {
+    "buttons": {
+      "home": "Home",
+      "noteSettings": "Settings"
+    }
+  },
   "home": {
-    "title": "Home",
-    "settings": "Settings"
+    "title": "Recent Notes"
   },
   "errors": {
     "404": "Page not found",

--- a/src/presentation/components/header/Header.vue
+++ b/src/presentation/components/header/Header.vue
@@ -40,7 +40,7 @@ const { user } = useAppState();
 const tabs = computed<Tab[]>(() => {
   const availableTabs = [
     {
-      title: t('home.title'),
+      title: t('header.buttons.home'),
       path: '/',
       icon: IconPicture,
       isActive: currentRoute.value.name === 'home',
@@ -53,7 +53,7 @@ const tabs = computed<Tab[]>(() => {
    */
   if ( currentRoute.value.name === 'note') {
     availableTabs.push({
-      title: t('home.settings'),
+      title: t('header.buttons.noteSettings'),
       path: currentRoute.value.path + '/settings',
       icon: IconMenu,
       isActive: false,
@@ -66,7 +66,7 @@ const tabs = computed<Tab[]>(() => {
    */
   if ( currentRoute.value.name === 'settings') {
     availableTabs.push({
-      title: t('home.settings'),
+      title: t('header.buttons.noteSettings'),
       path: currentRoute.value.path,
       icon: IconMenu,
       isActive: true,

--- a/src/presentation/pages/Home.vue
+++ b/src/presentation/pages/Home.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <h1>Recent Notes</h1>
+    <h1>{{ $t('home.title') }}</h1>
     <p>This page will contain your Notes you recently worked with </p>
   </div>
 </template>


### PR DESCRIPTION
Since header and homepage are different entities, it’s worth making a different i18n for them. Before this, the same variables were used for header and homepage.