### PR TITLE
feature: adding list of tools in /marketplace

### DIFF
--- a/src/application/i18n/messages/en.json
+++ b/src/application/i18n/messages/en.json
@@ -19,5 +19,9 @@
     "404": "Page not found",
     "500": "Unknown error happened",
     "default": "Something went wrong"
+  },
+  "marketplace": {
+    "title": "Marketplace",
+    "listOfTools": "Tools"
   }
 }

--- a/src/application/router/routes.ts
+++ b/src/application/router/routes.ts
@@ -4,6 +4,7 @@ import Landing from '@/presentation/pages/Landing.vue';
 import Settings from '@/presentation/pages/Settings.vue';
 import NoteSettings from '@/presentation/pages/NoteSettings.vue';
 import ErrorPage from '@/presentation/pages/Error.vue';
+import Marketplace from '@/presentation/pages/Marketplace.vue';
 import type { RouteRecordRaw } from 'vue-router';
 
 // Default production hostname for homepage. If different, then custom hostname used
@@ -54,6 +55,10 @@ const routes: RouteRecordRaw[] = [
     props: route => ({
       id: String(route.params.id),
     }),
+  },
+  {
+    path: `/marketplace/`,
+    component: Marketplace,
   },
   /**
    * 404 page

--- a/src/application/services/useAppState.ts
+++ b/src/application/services/useAppState.ts
@@ -2,7 +2,7 @@ import { AppStateController } from '@/domain';
 import type { User } from '@/domain/entities/User';
 import { createSharedComposable } from '@vueuse/core';
 import { type Ref, ref } from 'vue';
-
+import  type { EditorTool } from '@/domain/entities/EditorTool';
 /**
  * Composable for the application state
  */
@@ -11,6 +11,7 @@ interface UseAppStateComposable {
    * Current authenticated user
    */
   user: Ref<User | null>;
+  editorTools: Ref<EditorTool[]>
 }
 
 /**
@@ -21,17 +22,22 @@ export const useAppState = createSharedComposable((): UseAppStateComposable => {
    * Current authenticated user
    */
   const user = ref<User | null>(null);
+  const editorTools = ref<EditorTool[]>([]);
 
   /**
    * Subscribe to user changes in the App State
    */
-  AppStateController.user((prop: 'user', value: User | null) => {
+  AppStateController.user((prop: 'user' | 'editorTools', value: User | EditorTool[] | null) => {
     if (prop === 'user') {
-      user.value = value;
+      user.value = value as User;
+    }
+    if (prop === 'editorTools') {
+      editorTools.value = value as EditorTool[];
     }
   });
 
   return {
     user,
+    editorTools,
   };
 });

--- a/src/domain/entities/EditorTool.ts
+++ b/src/domain/entities/EditorTool.ts
@@ -34,9 +34,10 @@ export interface EditorTool {
      * Source of the tool to get it's code
      */
     source: {
-        /**
-         * Tool URL in content delivery network
-         */
+    /**
+     * Tool URL in content delivery network
+     */
+
         cdn?: string;
     }
 }

--- a/src/domain/entities/EditorTool.ts
+++ b/src/domain/entities/EditorTool.ts
@@ -8,20 +8,22 @@ export interface EditorTool {
     id: string;
 
     /**
-     * Technical id of the tool, like 'header', 'list', 'linkTool'
-     */
-    pluginId: string;
-
-    /**
-     * User-friendly plugin title
+     * Plugin id that editor will use,
+     *  e.g. "warning", "list", "linkTool"
      */
     name: string;
 
     /**
-     * Name of the tool class. Since it's imported globally,
-     * we need the class name to properly connect the tool to the editor
+     * User-friendly name that will be shown in marketplace,
+     *  .e.g "Warning tool 3000"
      */
-    class: string;
+    title: string;
+
+    /**
+     *Name of the plugin's class,
+      e.g. "LinkTool", "Checklist", "Header"
+     */
+    exportName: string;
 
     /**
      * Is plugin included by default in the editor

--- a/src/domain/entities/EditorTool.ts
+++ b/src/domain/entities/EditorTool.ts
@@ -1,0 +1,40 @@
+/**
+ * Plugin that connects to the editor based on user settings
+ */
+export interface EditorTool {
+    /**
+     * Unique identifier of the tool. Nano-ID
+     */
+    id: string;
+
+    /**
+     * Technical id of the tool, like 'header', 'list', 'linkTool'
+     */
+    pluginId: string;
+
+    /**
+     * User-friendly plugin title
+     */
+    name: string;
+
+    /**
+     * Name of the tool class. Since it's imported globally,
+     * we need the class name to properly connect the tool to the editor
+     */
+    class: string;
+
+    /**
+     * Is plugin included by default in the editor
+     */
+    isDefault?: boolean;
+
+    /**
+     * Source of the tool to get it's code
+     */
+    source: {
+        /**
+         * Tool URL in content delivery network
+         */
+        cdn?: string;
+    }
+}

--- a/src/domain/tools.repository.interface.ts
+++ b/src/domain/tools.repository.interface.ts
@@ -1,0 +1,16 @@
+import type { EditorTool } from './entities/EditorTool';
+
+/**
+ * Repository interface describes the methods that required by domain for its business logic implementation
+ */
+export default interface EditorToolRepositoryInterface {
+  /**
+   * Loads and stores editor tools data
+   */
+  loadEditorTool: () => Promise<void>;
+
+  /**
+   * Return stored editor tools data
+   */
+  getEditorTool: () => EditorTool | null;
+}

--- a/src/domain/tools.service.ts
+++ b/src/domain/tools.service.ts
@@ -1,0 +1,28 @@
+import type EditorToolRepository from '@/domain/tools.repository.interface';
+import type { EditorTool } from './entities/EditorTool';
+
+/**
+ * Business logic for EditorTool
+ */
+export default class EditorToolService {
+  /**
+   * Facade for accessing tools
+   */
+  private readonly repository: EditorToolRepository;
+
+  /**
+   * Service constructor
+   *
+   * @param eventBus - Common domain event bus
+   * @param editorToolRepository - repository instance
+   */
+  constructor(editorToolRepository: EditorToolRepository) {
+    this.repository = editorToolRepository;
+  }
+  /**
+   * Returns editor tool data
+   */
+  public getEditorTool(): EditorTool | null {
+    return this.repository.getEditorTool();
+  }
+}

--- a/src/infrastructure/index.ts
+++ b/src/infrastructure/index.ts
@@ -8,6 +8,8 @@ import UserRepository from '@/infrastructure/user.repository';
 import { UserStore } from '@/infrastructure/storage/user';
 import type EventBus from '@/domain/event-bus';
 import { AUTH_COMPLETED_EVENT_NAME, type AuthCompletedEvent } from '@/domain/event-bus/events/AuthCompleted';
+import EditorToolRepository from './tools.repository';
+import { EditorToolStore } from './storage/tools';
 
 /**
  * Repositories
@@ -32,6 +34,12 @@ export interface Repositories {
    * Working with User data
    */
   user: UserRepository;
+
+  /**
+   * Working with tools
+   */
+
+  tools: EditorToolRepository;
 }
 
 /**
@@ -47,6 +55,7 @@ export function init(noteApiUrl: string, eventBus: EventBus): Repositories {
   const noteStore = new NoteStore();
   const authStore = new AuthStore();
   const userStore = new UserStore();
+  const editorToolStore = new EditorToolStore();
 
   /**
    * Init transport
@@ -82,11 +91,13 @@ export function init(noteApiUrl: string, eventBus: EventBus): Repositories {
   const noteSettingsRepository = new NoteSettingsRepository(notesApiTransport);
   const authRepository = new AuthRepository(authStore, notesApiTransport);
   const userRepository = new UserRepository(userStore, notesApiTransport);
+  const editorToolRepository = new EditorToolRepository(editorToolStore, notesApiTransport);
 
   return {
     note: noteRepository,
     noteSettings: noteSettingsRepository,
     auth: authRepository,
     user: userRepository,
+    tools: editorToolRepository,
   };
 }

--- a/src/infrastructure/storage/tools.ts
+++ b/src/infrastructure/storage/tools.ts
@@ -1,0 +1,31 @@
+import type { EditorTool } from '@/domain/entities/EditorTool';
+import { SubscribableStore } from './abstract/subscribable';
+
+/**
+ * Data stored in the user store
+ */
+export type EditorToolStoreData = {
+  /**
+   * User data
+   */
+  editorTool: EditorTool | null;
+};
+
+/**
+ * Store for the editor tools
+ */
+export class EditorToolStore extends SubscribableStore<EditorToolStoreData> {
+  /**
+   * Returns tools
+   */
+  public getEditorTool(): EditorTool | null {
+    return this.data.editorTool;
+  }
+  /**
+     * Sets tools
+     * @param editorTool
+     */
+  public setEditorTools(editorTool: EditorTool): void {
+    this.data.editorTool = editorTool;
+  }
+}

--- a/src/infrastructure/tools.repository.ts
+++ b/src/infrastructure/tools.repository.ts
@@ -1,0 +1,44 @@
+import type EditorToolRepositoryInterface from '@/domain/tools.repository.interface';
+import type NotesApiTransport from './transport/notes-api';
+import type { EditorToolStore, EditorToolStoreData } from './storage/tools';
+import type { EditorTool } from '@/domain/entities/EditorTool';
+import Repository from './repository';
+
+/**
+ * Facade for the editor tools
+ */
+export default class EditorToolRepository extends Repository<EditorToolStore, EditorToolStoreData> implements EditorToolRepositoryInterface  {
+  /**
+   * Transport instance
+   */
+  private readonly transport: NotesApiTransport;
+
+  /**
+   * Repository constructor
+   
+   * @param store - stores editor tools
+   * @param notesApiTransport - notes api transport instance
+   */
+  constructor(store: EditorToolStore, notesApiTransport: NotesApiTransport) {
+    super(store);
+
+    this.transport = notesApiTransport;
+  }
+
+
+  /**
+   *
+   */
+  public async loadEditorTool(): Promise<void> {
+    const response = await this.transport.get<EditorTool>('/editor-tools/all');
+
+    this.store.setEditorTools(response);
+  };
+
+  /**
+   * Load editor tools data and put it to the storage
+   */
+  public getEditorTool(): EditorTool | null  {
+    return this.store.getEditorTool();
+  }
+}

--- a/src/infrastructure/tools.repository.ts
+++ b/src/infrastructure/tools.repository.ts
@@ -15,7 +15,7 @@ export default class EditorToolRepository extends Repository<EditorToolStore, Ed
 
   /**
    * Repository constructor
-   
+   *
    * @param store - stores editor tools
    * @param notesApiTransport - notes api transport instance
    */
@@ -25,9 +25,8 @@ export default class EditorToolRepository extends Repository<EditorToolStore, Ed
     this.transport = notesApiTransport;
   }
 
-
   /**
-   *
+   * Api request to get list of tools
    */
   public async loadEditorTool(): Promise<void> {
     const response = await this.transport.get<EditorTool>('/editor-tools/all');

--- a/src/presentation/pages/Marketplace.vue
+++ b/src/presentation/pages/Marketplace.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <h1>Marketplace</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>
+
+<style setup lang = "postcss" scoped>
+@import '@/presentation/styles/typography.pcss';
+
+h1 {
+    @apply --text-heading-1;
+}
+</style>

--- a/src/presentation/pages/Marketplace.vue
+++ b/src/presentation/pages/Marketplace.vue
@@ -6,7 +6,7 @@
     :key="tool.id"
   >
     <li>
-      {{ tool.name }}
+      {{ tool.title }}
     </li>
   </ul>
 </template>

--- a/src/presentation/pages/Marketplace.vue
+++ b/src/presentation/pages/Marketplace.vue
@@ -1,10 +1,20 @@
 <template>
-  <div>
-    <h1>Marketplace</h1>
-  </div>
+  <h1>{{ $t('marketplace.title') }}</h1>
+  <h2>{{ $t('marketplace.listOfTools') }}</h2>
+  <ul
+    v-for="tool in editorTools"
+    :key="tool.id"
+  >
+    <li>
+      {{ tool.name }}
+    </li>
+  </ul>
 </template>
 
-<script setup lang="ts">
+<script lang = "ts" setup>
+import { useAppState } from '@/application/services/useAppState';
+
+const { editorTools } = useAppState();
 </script>
 
 <style setup lang = "postcss" scoped>


### PR DESCRIPTION
Task: "Add list of tools to /marketplace"

Done:

-  created /marketplace page and route to it  (Marketplace.vue, routes.ts)
-  added editor tools to entities(EditorTool.ts)
-  created interface for repository of tools(tools.repository.interface.ts)
-  created  repository of tools and implemented method of getting list of tools from backend(tools.repository.ts)
-  created editor tool service class(tools.service.ts)
-  added tool repository to initialization of repositories function (index.ts)
-  added list of tools in useAppState(useAppState.ts)

I have no idea why list of tools doesn't appear at page /marketplace.