### PR TITLE
Added getting note access rights from note.api

### DIFF
--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -96,7 +96,7 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
     /**
      * @todo try-catch domain errors
      */
-    note.value = await noteService.getNoteById(id);
+    note.value = (await noteService.getNoteById(id)).note;
   };
 
   /**
@@ -136,7 +136,7 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
    * Get note by custom hostname
    */
   const resolveHostname = async (): Promise<void> => {
-    note.value = await noteService.getNoteByHostname(location.hostname);
+    note.value = (await noteService.getNoteByHostname(location.hostname)).note;
   };
 
   onMounted(() => {

--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -3,7 +3,6 @@ import { noteService } from '@/domain';
 import type { Note, NoteContent, NoteId } from '@/domain/entities/Note';
 import { useRouter } from 'vue-router';
 
-
 /**
  * On new note creation, we use predefined structure of the Editor: header + paragraph
  * We call it NoteDraft
@@ -109,7 +108,6 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
     /**
      * @todo try-catch domain errors
      */
-
     const response = await noteService.getNoteById(id);
 
     note.value = response.note;

--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -1,7 +1,6 @@
 import { onMounted, ref, type Ref, type MaybeRefOrGetter, computed, toValue, watch } from 'vue';
 import { noteService } from '@/domain';
 import type { Note, NoteContent, NoteId } from '@/domain/entities/Note';
-import type NoteAccessRights from '@/domain/entities/NoteAccessRights';
 import { useRouter } from 'vue-router';
 
 
@@ -38,15 +37,6 @@ function createDraft(): NoteDraft {
 }
 
 /**
- * Create access rights for the empty note
- */
-function createAccessRights(): NoteAccessRights {
-  return {
-    canEdit: true,
-  };
-}
-
-/**
  * Note hook state
  */
 interface UseNoteComposableState {
@@ -68,10 +58,9 @@ interface UseNoteComposableState {
   resolveHostname: () => Promise<void>;
 
   /**
-   * NoteAccessRights - when note is loaded or new note created
-   * null - when note and its access rights is not loaded yet
+   * Defines if user can edit note
    */
-  accessRights: Ref<NoteAccessRights | null>;
+  canEdit: Ref<boolean>;
 }
 
 interface UseNoteComposableOptions {
@@ -105,11 +94,11 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
   const router = useRouter();
 
   /**
-   * Access rights for currently opened note
+   * Editing rights for the currently opened note
    *
-   * Create new NoteAccessRights instance when new note is created
+   * true by default
    */
-  const accessRights = ref<NoteAccessRights | null>(currentId.value == null ? createAccessRights() : null);
+  const canEdit = ref<boolean>(true);
 
   /**
    * Load note by id
@@ -124,7 +113,7 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
     const response = await noteService.getNoteById(id);
 
     note.value = response.note;
-    accessRights.value = response.accessRights;
+    canEdit.value = response.accessRights.canEdit;
   }
 
   /**
@@ -183,7 +172,7 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
      */
     if (newId === null) {
       note.value = createDraft();
-      accessRights.value = createAccessRights();
+      canEdit.value = true;
 
       return;
     }
@@ -201,7 +190,7 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
 
   return {
     note,
-    accessRights,
+    canEdit,
     resolveHostname,
     save,
   };

--- a/src/domain/entities/NoteAccessRights.ts
+++ b/src/domain/entities/NoteAccessRights.ts
@@ -1,0 +1,10 @@
+/**
+ * NoteAccessRights entity
+ */
+
+export default interface NoteAccessRights {
+  /**
+   * Access to edit note
+   */
+  canEdit: boolean;
+}

--- a/src/domain/note.repository.interface.ts
+++ b/src/domain/note.repository.interface.ts
@@ -1,5 +1,5 @@
 import type { Note, NoteContent } from '@/domain/entities/Note';
-import type NoteAccessRights from '@/domain/entities/NoteAccessRights.ts';
+import type NoteAccessRights from '@/domain/entities/NoteAccessRights';
 
 /**
  * Repository interface describes the methods that required by domain for its business logic implementation
@@ -10,7 +10,7 @@ export default interface NoteRepositoryInterface {
    * Returns a Note and NoteAccessRights by id
    *
    * @param publicId - Note id
-   * @returns note - Note instance, accessRights - NoteAccessRights instance
+   * @returns {{ note: Note, accessRights: NoteAccessRights }} - Note instance and NoteAccessRights instance
    * @throws NotFoundError
    */
   getNoteById(publicId: string): Promise<{ note: Note, accessRights: NoteAccessRights }>;
@@ -19,7 +19,7 @@ export default interface NoteRepositoryInterface {
    * Returns a Note and NoteAccessRights by hostname
    *
    * @param hostname - Custom hostname
-   * @returns note - Note instance, accessRights - NoteAccessRights instance
+   * @returns {{ note: Note, accessRights: NoteAccessRights }} - Note instance and NoteAccessRights instance
    */
   getNoteByHostname(hostname: string): Promise<{ note: Note, accessRights: NoteAccessRights }>;
 

--- a/src/domain/note.repository.interface.ts
+++ b/src/domain/note.repository.interface.ts
@@ -1,4 +1,5 @@
 import type { Note, NoteContent } from '@/domain/entities/Note';
+import type NoteAccessRights from '@/domain/entities/NoteAccessRights.ts';
 
 /**
  * Repository interface describes the methods that required by domain for its business logic implementation
@@ -6,21 +7,21 @@ import type { Note, NoteContent } from '@/domain/entities/Note';
 export default interface NoteRepositoryInterface {
 
   /**
-   * Returns a Note by id
+   * Returns a Note and NoteAccessRights by id
    *
    * @param publicId - Note id
-   * @returns Note | null - Note instance
+   * @returns note - Note instance, accessRights - NoteAccessRights instance
    * @throws NotFoundError
    */
-  getNoteById(publicId: string): Promise<Note>;
+  getNoteById(publicId: string): Promise<{ note: Note, accessRights: NoteAccessRights }>;
 
   /**
-   * Returns a Note by hostname
+   * Returns a Note and NoteAccessRights by hostname
    *
    * @param hostname - Custom hostname
-   * @returns Note | null - Note instance
+   * @returns note - Note instance, accessRights - NoteAccessRights instance
    */
-  getNoteByHostname(hostname: string): Promise<Note | null>;
+  getNoteByHostname(hostname: string): Promise<{ note: Note, accessRights: NoteAccessRights }>;
 
   /**
    * Creates a new note

--- a/src/domain/note.service.ts
+++ b/src/domain/note.service.ts
@@ -1,5 +1,6 @@
 import type NoteRepository from '@/domain/note.repository.interface';
 import type { Note, NoteContent } from '@/domain/entities/Note';
+import type NoteAccessRights from '@/domain/entities/NoteAccessRights';
 
 /**
  * Note Service
@@ -20,22 +21,23 @@ export default class NoteService {
   }
 
   /**
-   * Returns a note by its id
+   * Returns a note and accessRights by its id
    *
    * @param id - Note identifier
    * @throws NotFoundError
+   * @returns {{ note: Note, accessRights: NoteAccessRights }} - note data and accessRights data
    */
-  public async getNoteById(id: string): Promise<Note> {
+  public async getNoteById(id: string): Promise<{ note: Note, accessRights: NoteAccessRights }> {
     return await this.noteRepository.getNoteById(id);
   }
 
   /**
-   * Get note by hostname
+   * Get note and accessRights by hostname
    *
    * @param hostname - Custom hostname linked with a note
-   * @returns { Note | null } - Note data
+   * @returns {{ note: Note, accessRights: NoteAccessRights }} - note data and accessRights data
    */
-  public async getNoteByHostname(hostname: string): Promise<Note | null> {
+  public async getNoteByHostname(hostname: string): Promise<{ note: Note, accessRights: NoteAccessRights }> {
     return await this.noteRepository.getNoteByHostname(hostname);
   }
 

--- a/src/infrastructure/note.repository.ts
+++ b/src/infrastructure/note.repository.ts
@@ -5,7 +5,6 @@ import type NoteStorage from '@/infrastructure/storage/note.js';
 import type NotesApiTransport from '@/infrastructure/transport/notes-api';
 import type { GetNoteResponsePayload } from '@/infrastructure/transport/notes-api/types/GetNoteResponsePayload';
 
-
 /**
  * Note repository
  */

--- a/src/infrastructure/note.repository.ts
+++ b/src/infrastructure/note.repository.ts
@@ -1,8 +1,10 @@
 import type NoteRepositoryInterface from '@/domain/note.repository.interface';
 import type { Note, NoteContent, NoteId } from '@/domain/entities/Note';
+import type NoteAccessRights from '@/domain/entities/NoteAccessRights';
 import type NoteStorage from '@/infrastructure/storage/note.js';
 import type NotesApiTransport from '@/infrastructure/transport/notes-api';
 import type { GetNoteResponsePayload } from '@/infrastructure/transport/notes-api/types/GetNoteResponsePayload';
+
 
 /**
  * Note repository
@@ -34,8 +36,9 @@ export default class NoteRepository implements NoteRepositoryInterface {
    *
    * @param id - Note identifier
    * @throws NotFoundError
+   * @returns {{ note: Note, accessRights: NoteAccessRights }} - Note instance and NoteAccessRights instance
    */
-  public async getNoteById(id: string): Promise<Note> {
+  public async getNoteById(id: string): Promise<{ note: Note, accessRights: NoteAccessRights }> {
     /**
      * Get note data from API
      */
@@ -46,9 +49,9 @@ export default class NoteRepository implements NoteRepositoryInterface {
    * Get note by hostname
    *
    * @param hostname - Custom hostname linked with one Note
-   * @returns { Note | null } - Note instance
+   * @returns {{ note: Note, accessRights: NoteAccessRights }} - Note instance and NoteAccessRights instance
    */
-  public async getNoteByHostname(hostname: string): Promise<Note | null> {
+  public async getNoteByHostname(hostname: string): Promise<{ note: Note, accessRights: NoteAccessRights }> {
     /**
      * Get note data from API
      */

--- a/src/infrastructure/transport/notes-api/types/GetNoteResponsePayload.ts
+++ b/src/infrastructure/transport/notes-api/types/GetNoteResponsePayload.ts
@@ -1,6 +1,10 @@
 import type { Note } from '@/domain/entities/Note';
+import type NoteAccessRights from '@/domain/entities/NoteAccessRights.ts';
 
 /**
  * Get note response payload
  */
-export type GetNoteResponsePayload = Note;
+export type GetNoteResponsePayload = {
+  note: Note,
+  accessRights: NoteAccessRights
+};

--- a/src/presentation/components/editor/Editor.vue
+++ b/src/presentation/components/editor/Editor.vue
@@ -61,6 +61,7 @@ function loadScript(src: string) {
  */
 const props = defineProps<{
   content?: OutputData,
+  readOnly?: boolean,
 }>();
 
 const emit = defineEmits<{
@@ -185,6 +186,7 @@ const mountEditorOnce = async () => {
       },
       data: props.content,
       onChange,
+      readOnly: props.readOnly,
     });
 
     await editorInstance.isReady;

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -6,6 +6,7 @@
     v-else
     ref="editor"
     :content="note.content"
+    :read-only="!accessRights?.canEdit"
     @change="noteChanged"
   />
 </template>
@@ -25,7 +26,7 @@ const props = defineProps<{
 
 const noteId = computed(() => props.id);
 
-const { note, save } = useNote({
+const { note, save, accessRights } = useNote({
   id: noteId,
 });
 

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -6,7 +6,7 @@
     v-else
     ref="editor"
     :content="note.content"
-    :read-only="!accessRights?.canEdit"
+    :read-only="!canEdit"
     @change="noteChanged"
   />
 </template>
@@ -26,7 +26,7 @@ const props = defineProps<{
 
 const noteId = computed(() => props.id);
 
-const { note, save, accessRights } = useNote({
+const { note, save, canEdit } = useNote({
   id: noteId,
 });
 


### PR DESCRIPTION
This PR is related to pr122 in notes.api
Changes:
- added NoteAccessRights entity
- GetNoteResponsePayload now have { note: Note, accessRights: NoteAccessRights } structure
- NoteRepositoryInterface, NoteRepository, NoteService, UseNote updated to work with new note payload
- Removed cases when trying to get a note by its hostname could return null (because when the note is not found,   a    NotFoundError should be thrown)