### PR TITLE
feat(ui): playground added

### DIFF
--- a/codex-ui/README.md
+++ b/codex-ui/README.md
@@ -10,7 +10,7 @@
 - [ ] Make tree-shaking work
 - [ ] Prepare hooks/composables example
 - [ ] Fix Eslint
-- [ ] Improve DX for components debug
+- [x] Improve DX for components debug
 - [ ] Test Web/React/Native implementations
 - [ ] Think about i18n
 

--- a/codex-ui/dev/Playground.vue
+++ b/codex-ui/dev/Playground.vue
@@ -1,0 +1,30 @@
+<template>
+  <div :class="$style.playground">
+    <Heading :level="1">
+      Playground
+    </Heading>
+    <Heading :level="3">
+      Button
+    </Heading>
+    <Button text="Click me" />
+    <Heading :level="3">
+      Input
+    </Heading>
+    <Input text="Enter email" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Button, Heading, Input } from '../src/vue';
+
+</script>
+
+<style module>
+.playground {
+  background-color: var(--base--bg-primary);
+  color: var(--base--text);
+  min-height: 100%;
+  padding: 20px;
+  font-family: ;
+}
+</style>

--- a/codex-ui/dev/index.html
+++ b/codex-ui/dev/index.html
@@ -1,0 +1,26 @@
+<body
+  theme-base="classic"
+  theme-accent="classic"
+>
+  <link
+    rel="stylesheet"
+    href="../src/styles/index.pcss"
+  />
+  <div id="app"></div>
+  <script type="module">
+    import { createApp, ref, h } from 'vue';
+    import Playground from './Playground.vue';
+
+    createApp({
+      render() {
+        return h(Playground);
+      },
+    }).mount('#app');
+  </script>
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+    }
+  </style>
+</body>

--- a/codex-ui/dev/index.html
+++ b/codex-ui/dev/index.html
@@ -8,7 +8,7 @@
   />
   <div id="app"></div>
   <script type="module">
-    import { createApp, ref, h } from 'vue';
+    import { createApp, h } from 'vue';
     import Playground from './Playground.vue';
 
     createApp({

--- a/codex-ui/src/styles/fonts.pcss
+++ b/codex-ui/src/styles/fonts.pcss
@@ -1,0 +1,17 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
+
+body {
+  font-family:
+    'Inter',
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    'Helvetica Neue',
+    Arial,
+    sans-serif;
+  font-optical-sizing: auto;
+  font-style: normal;
+  font-variation-settings: 'slnt' 0;
+}

--- a/codex-ui/src/styles/index.pcss
+++ b/codex-ui/src/styles/index.pcss
@@ -1,1 +1,2 @@
+@import './fonts.pcss';
 @import './themes/index.pcss';

--- a/codex-ui/src/styles/themes/classic.pcss
+++ b/codex-ui/src/styles/themes/classic.pcss
@@ -3,16 +3,16 @@ body[theme-accent='classic'] {
   /**
   * Classic Dark Colors
   */
-  --classic--bg-primary: #000000;
-  --classic--bg-secondary: #000000;
-  --classic--bg-secondary-hover: #191919;
-  --classic--bg-input: #191919;
-  --classic--border: #1c1c1c;
-  --classic--solid-hover: #f8fd1a;
-  --classic--solid: #3e3e3e;
-  --classic--text-secondary: #828282;
-  --classic--text: #ffffff;
-  --classic--text-solid-foreground: #ffffff;
+  --classic--bg-primary: #242527;
+  --classic--bg-secondary: #2c2d30;
+  --classic--bg-secondary-hover: #3b3c40;
+  --classic--bg-input: #e70037;
+  --classic--border: #363940;
+  --classic--solid-hover: #183b65;
+  --classic--solid: #1c84ff;
+  --classic--text-secondary: #94979a;
+  --classic--text: #f5f5f5;
+  --classic--text-solid-foreground: #f5f5f5;
 }
 
 /**

--- a/codex-ui/src/vue/button/Button.vue
+++ b/codex-ui/src/vue/button/Button.vue
@@ -19,7 +19,13 @@ const props = defineProps<{
 
 <style lang="postcss" module>
 .button {
-  border: 1px solid green;
-  background-color: blue;
+  background-color: var(--base--solid);
+  border: 0;
+  outline: 0;
+  color: var(--classic--text-solid-foreground);
+  padding: 8px 12px;
+  font-size: 14px;
+  font-weight: 500;
+  border-radius: 8px;
 }
 </style>

--- a/codex-ui/src/vue/button/Button.vue
+++ b/codex-ui/src/vue/button/Button.vue
@@ -22,7 +22,7 @@ const props = defineProps<{
   background-color: var(--base--solid);
   border: 0;
   outline: 0;
-  color: var(--classic--text-solid-foreground);
+  color: var(--base--text-solid-foreground);
   padding: 8px 12px;
   font-size: 14px;
   font-weight: 500;

--- a/codex-ui/src/vue/heading/Heading.vue
+++ b/codex-ui/src/vue/heading/Heading.vue
@@ -1,8 +1,5 @@
 <template>
-  <component
-    :is="`h${props.level}`"
-    :class="$style.heading"
-  >
+  <component :is="`h${props.level}`" :class="$style.heading">
     <slot />
   </component>
 </template>
@@ -21,7 +18,15 @@ const props = defineProps<{
 <style module>
 @import '@/styles/mixins/typography.pcss';
 
-.heading {
+h1.heading {
   @apply --text-heading-1;
+}
+
+h2.heading {
+  @apply --text-heading-2;
+}
+
+h3.heading {
+  @apply --text-heading-3;
 }
 </style>

--- a/codex-ui/src/vue/input/Input.vue
+++ b/codex-ui/src/vue/input/Input.vue
@@ -1,9 +1,6 @@
 <template>
   <div>
-    <input
-      :class="$style.input"
-      :value="props.text"
-    />
+    <input class="input" :value="props.text" />
   </div>
 </template>
 
@@ -18,8 +15,15 @@ const props = defineProps<{
 }>();
 </script>
 
-<style lang="postcss" module>
+<style lang="postcss">
 .input {
-  background-color: red;
+  background-color: var(--base--bg-secondary);
+  border: 0;
+  outline: 0;
+  color: var(--base--text);
+  padding: 12px 16px;
+  border-radius: 12px;
+  font-size: inherit;
+  font-family: inherit;
 }
 </style>

--- a/codex-ui/vite.config.ts
+++ b/codex-ui/vite.config.ts
@@ -24,7 +24,6 @@ export default defineConfig({
       formats: ['es'],
     },
     cssCodeSplit: false,
-
     rollupOptions: {
       input: {
         styles: resolve(__dirname, 'src/styles/index.pcss'),

--- a/codex-ui/vite.config.ts
+++ b/codex-ui/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       formats: ['es'],
     },
     cssCodeSplit: false,
+
     rollupOptions: {
       input: {
         styles: resolve(__dirname, 'src/styles/index.pcss'),
@@ -46,5 +47,8 @@ export default defineConfig({
     alias: {
       '@/': '/src/',
     },
+  },
+  server: {
+    open: '/dev/index.html',
   },
 });


### PR DESCRIPTION
Now "codex-ui" package has a playground where we can implement and test components

- "yarn dev" now opens a playground
- Fonts setup added
- "Classic" theme colours updated
- "Button" and "Inputs" now uses colours from theme
- "Heading" component now supports 3 levels

![image](https://github.com/codex-team/notes.web/assets/3684889/ccd980ad-2569-4d01-8d03-0105415862d8)
