### PR TITLE
Fix create child note

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,7 +17,7 @@ useColorMode();
  * All errors inside the application
  */
 onErrorCaptured((error) => {
-  alert(error.message);
+  console.error(error.message);
 });
 </script>
 

--- a/src/application/services/useEditor.ts
+++ b/src/application/services/useEditor.ts
@@ -156,8 +156,9 @@ export function useEditor({ id, content, isReadOnly, onChange }: UseEditorParams
   }
 
   /**
+   * Reinitializes editor instance with new data
    *
-   * @param data
+   * @param data - new data to be displayed in editor
    */
   async function refresh(data?: OutputData): Promise<void> {
     editor?.destroy();

--- a/src/application/services/useEditor.ts
+++ b/src/application/services/useEditor.ts
@@ -45,6 +45,7 @@ interface UseEditorParams {
  */
 export function useEditor({ id, content, isReadOnly, onChange }: UseEditorParams): {
   isEmpty: Ref<boolean>;
+  refresh: (data: OutputData) => void;
 } {
   /**
    * Editor instance
@@ -130,14 +131,16 @@ export function useEditor({ id, content, isReadOnly, onChange }: UseEditorParams
 
   /**
    * Initializes editorjs instance
+   *
+   * @param data
    */
-  async function mountEditor(): Promise<void> {
+  async function mountEditor(data?: OutputData): Promise<void> {
     try {
       const tools = await downloadTools(userEditorTools);
 
       editor = new Editor({
         holder: id,
-        data: content,
+        data: data,
         tools: {
           header: Header,
           ...tools,
@@ -152,8 +155,17 @@ export function useEditor({ id, content, isReadOnly, onChange }: UseEditorParams
     }
   }
 
+  /**
+   *
+   * @param data
+   */
+  async function refresh(data?: OutputData): Promise<void> {
+    editor?.destroy();
+    await mountEditor(data);
+  }
+
   onMounted(() => {
-    void mountEditor();
+    void mountEditor(content);
   });
 
   /**
@@ -166,5 +178,6 @@ export function useEditor({ id, content, isReadOnly, onChange }: UseEditorParams
 
   return {
     isEmpty,
+    refresh,
   };
 }

--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -49,7 +49,7 @@ interface UseNoteComposableState {
   /**
    * Creates/updates the note
    */
-  save: (content: NoteContent, parentId: NoteId | null | undefined) => Promise<void>;
+  save: (content: NoteContent, parentId: NoteId | undefined) => Promise<void>;
 
   /**
    * Load note by custom hostname
@@ -97,10 +97,11 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
    */
   const router = useRouter();
 
+  const limitCharsForNoteTitle = 50;
+
   /**
    * Note Title identifier
    */
-  const limitCharsForNoteTitle = 50;
   const noteTitle = computed(() => {
     const firstNoteBlock = note.value?.content.blocks[0];
 
@@ -164,6 +165,7 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
     }
 
     await noteService.updateNoteContent(currentId.value, content);
+    note.value = { ...note.value, content };
   }
 
   /**

--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -49,7 +49,7 @@ interface UseNoteComposableState {
   /**
    * Creates/updates the note
    */
-  save: (content: NoteContent, parentId: NoteId | null) => Promise<void>;
+  save: (content: NoteContent, parentId: NoteId | null | undefined) => Promise<void>;
 
   /**
    * Load note by custom hostname
@@ -139,7 +139,7 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
    * @param content - Note content (Editor.js data)
    * @param parentId - Id of the parent note. If null, then it's a root note
    */
-  async function save(content: NoteContent, parentId: NoteId | null): Promise<void> {
+  async function save(content: NoteContent, parentId: NoteId | undefined): Promise<void> {
     if (note.value === null) {
       throw new Error('Note is not loaded yet');
     }

--- a/src/domain/note.repository.interface.ts
+++ b/src/domain/note.repository.interface.ts
@@ -34,9 +34,9 @@ export default interface NoteRepositoryInterface {
    * Creates a new note
    *
    * @param content - Note content (Editor.js data)
-   * @param parentId - Id of the parent note. If null, then it's a root note
+   * @param parentId - Id of the parent note. If undefined, then it's a root note
    */
-  createNote(content: NoteContent, parentId: NoteId | null): Promise<Note>;
+  createNote(content: NoteContent, parentId?: NoteId): Promise<Note>;
 
   /**
    * Updates a content of existing note

--- a/src/domain/note.service.ts
+++ b/src/domain/note.service.ts
@@ -45,7 +45,7 @@ export default class NoteService {
    * Creates a new note and returns it
    *
    * @param content - Note content (Editor.js data)
-   * @param parentId - Id of the parent note. If null, then it's a root note
+   * @param parentId - Id of the parent note. If omitted, then it's a root note
    */
   public async createNote(content: NoteContent, parentId?: NoteId): Promise<Note> {
     return await this.noteRepository.createNote(content, parentId);

--- a/src/domain/note.service.ts
+++ b/src/domain/note.service.ts
@@ -47,7 +47,7 @@ export default class NoteService {
    * @param content - Note content (Editor.js data)
    * @param parentId - Id of the parent note. If null, then it's a root note
    */
-  public async createNote(content: NoteContent, parentId: NoteId | null): Promise<Note> {
+  public async createNote(content: NoteContent, parentId?: NoteId): Promise<Note> {
     return await this.noteRepository.createNote(content, parentId);
   }
 

--- a/src/infrastructure/note.repository.ts
+++ b/src/infrastructure/note.repository.ts
@@ -71,11 +71,11 @@ export default class NoteRepository implements NoteRepositoryInterface {
    * Creates a new note
    *
    * @param content - Note content (Editor.js data)
-   * @param parentId - Id of the parent note. If null, then it's a root note
+   * @param parentId - Id of the parent note. If undefined, then it's a root note
    *
    * @todo API should return Note
    */
-  public async createNote(content: NoteContent, parentId: NoteId | null): Promise<Note> {
+  public async createNote(content: NoteContent, parentId?: NoteId): Promise<Note> {
     const response = await this.transport.post<{ id: NoteId }>('/note', {
       content,
       parentId,

--- a/src/presentation/components/editor/Editor.vue
+++ b/src/presentation/components/editor/Editor.vue
@@ -3,15 +3,20 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
-import { type OutputData, type API } from '@editorjs/editorjs';
+import { type OutputData } from '@editorjs/editorjs';
 import { useEditor } from '@/application/services/useEditor';
 
 /**
  * Define the props for the component
  */
 const props = defineProps<{
+  /**
+   * Editor content
+   */
   content?: OutputData;
+  /**
+   * True if editor content is not editable
+   */
   readOnly?: boolean;
 }>();
 
@@ -19,65 +24,11 @@ const emit = defineEmits<{
   change: [data: OutputData];
 }>();
 
-/**
- * Attribute containing is-empty state.
- * It is updated on every change of the editor
- */
-const isEmpty = ref(true);
-
-/**
- * Checks if the editor is empty
- * Uses EditorJS API:
- *  - blocks.getById()
- *  - block.isEmpty()
- *
- * @todo implement "isEmpty" method in the EditorJS API
- *
- * @param data - saved data
- * @param api - EditorJS API
- */
-function checkIsEmpty(data: OutputData, api: API): boolean {
-  const blockIds = data.blocks.map((block) => block.id);
-
-  return blockIds.reduce((acc, id) => {
-    if (id === undefined) {
-      return acc;
-    }
-
-    const block = api.blocks.getById(id);
-
-    if (block) {
-      return acc && block.isEmpty;
-    }
-
-    return acc;
-  }, true);
-}
-
-/**
- * Function called on every change of the editor
- *
- * @param api - EditorJS API
- */
-async function onChange(api: API): Promise<void> {
-  const data = await api.saver.save();
-
-  /**
-   * Update the isEmpty attribute
-   */
-  isEmpty.value = checkIsEmpty(data, api);
-
-  /**
-   * Change model value
-   */
-  emit('change', data);
-}
-
-useEditor({
+const { isEmpty } = useEditor({
   id: 'editorjs',
   content: props.content,
   isReadOnly: props.readOnly,
-  onChange,
+  onChange: (data) => emit('change', data),
 });
 
 defineExpose({

--- a/src/presentation/components/editor/Editor.vue
+++ b/src/presentation/components/editor/Editor.vue
@@ -24,7 +24,7 @@ const emit = defineEmits<{
   change: [data: OutputData];
 }>();
 
-const { isEmpty } = useEditor({
+const { isEmpty, refresh } = useEditor({
   id: 'editorjs',
   content: props.content,
   isReadOnly: props.readOnly,
@@ -38,6 +38,11 @@ defineExpose({
   isEmpty() {
     return isEmpty.value;
   },
+
+  /**
+   * Reinitialize editor instance with new data
+   */
+  refresh,
 });
 </script>
 

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -84,26 +84,22 @@ watch(
     /** If new child note is created, refresh editor with empty data */
     if (props.id === null) {
       editor.value?.refresh();
-    }
-  }
-);
 
-/**
- * Changing the title in the browser
- */
-if (!props.id) {
-  useHead({
-    title: t('note.new'),
-  });
-} else {
-  watchEffect(() => {
-    if (noteTitle.value) {
       useHead({
-        title: noteTitle.value,
+        title: t('note.new'),
+      });
+    } else {
+      watchEffect(() => {
+        if (noteTitle.value) {
+          useHead({
+            title: noteTitle.value,
+          });
+        }
       });
     }
-  });
-}
+  },
+  { immediate: true }
+);
 </script>
 
 <style scoped></style>

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -7,6 +7,7 @@
         @click.passive="createChildNote"
       />
     </div>
+
     <Editor
       ref="editor"
       :content="note.content"
@@ -17,7 +18,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { Button } from 'codex-ui/vue';
 import Editor from '@/presentation/components/editor/Editor.vue';
 import useNote from '@/application/services/useNote';
@@ -76,6 +77,16 @@ function createChildNote(): void {
   }
   router.push(`/note/${props.id}/new`);
 }
+
+watch(
+  () => props.id,
+  () => {
+    /** If new child note is created, refresh editor with empty data */
+    if (props.id === null) {
+      editor.value?.refresh();
+    }
+  }
+);
 
 /**
  * Changing the title in the browser

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -40,7 +40,7 @@ const props = defineProps<{
   /**
    * Parent note id, null for root note
    */
-  parentId: string | null;
+  parentId?: string | null;
 }>();
 
 const noteId = computed(() => props.id);

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, watch } from 'vue';
+import { ref, toRef, watch } from 'vue';
 import { Button } from 'codex-ui/vue';
 import Editor from '@/presentation/components/editor/Editor.vue';
 import useNote from '@/application/services/useNote';
@@ -26,7 +26,6 @@ import { useRouter } from 'vue-router';
 import { NoteContent } from '@/domain/entities/Note';
 import { useHead } from 'unhead';
 import { useI18n } from 'vue-i18n';
-import { watchEffect } from 'vue';
 
 const { t } = useI18n();
 
@@ -39,12 +38,12 @@ const props = defineProps<{
   id: string | null;
 
   /**
-   * Parent note id, null for root note
+   * Parent note id, undefined for root note
    */
-  parentId?: string | null;
+  parentId?: string;
 }>();
 
-const noteId = computed(() => props.id);
+const noteId = toRef(props, 'id');
 
 const { note, save, noteTitle, canEdit } = useNote({
   id: noteId,
@@ -88,18 +87,18 @@ watch(
       useHead({
         title: t('note.new'),
       });
-    } else {
-      watchEffect(() => {
-        if (noteTitle.value) {
-          useHead({
-            title: noteTitle.value,
-          });
-        }
-      });
     }
   },
   { immediate: true }
 );
+
+watch(noteTitle, () => {
+  if (props.id !== null) {
+    useHead({
+      title: noteTitle.value,
+    });
+  }
+});
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
- Update editor once page route changes to '/note/:noteId/new'
- Replace `alert` with `console.error` in global errors handler
- Move more logic to `useEditor`