### PR TITLE
feat(ui): button styles and states

### DIFF
--- a/codex-ui/dev/Playground.vue
+++ b/codex-ui/dev/Playground.vue
@@ -1,12 +1,24 @@
 <template>
   <div :class="$style.playground">
     <Heading :level="1">Playground</Heading>
+
     <Heading :level="3">Buttons</Heading>
-    <Button size="small">Button</Button><br />
-    <Button>Button</Button><br />
-    <Button size="large">Button</Button><br />
+    <div :class="$style.buttons">
+      <div v-for="button in buttons">
+        <Button
+          :size="button[0]"
+          :secondary="button[1] === 'secondary'"
+          :disabled="button[1] === 'disabled'"
+          :destructive="button[1] === 'destructive'"
+        >
+          Button
+        </Button>
+      </div>
+    </div>
+
     <Heading :level="3"> Input </Heading>
     <Input text="Enter email" />
+
     <Heading :level="3"> Type Scale </Heading>
     <TypeScale />
   </div>
@@ -15,6 +27,24 @@
 <script setup lang="ts">
 import { Button, Heading, Input } from '../src/vue';
 import TypeScale from './TypeScale.vue';
+
+/**
+ * Button samples in different states
+ */
+const buttons = [
+  ['small'],
+  ['small', 'secondary'],
+  ['small', 'destructive'],
+  ['small', 'disabled'],
+  ['medium'],
+  ['medium', 'secondary'],
+  ['medium', 'destructive'],
+  ['medium', 'disabled'],
+  ['large'],
+  ['large', 'secondary'],
+  ['large', 'destructive'],
+  ['large', 'disabled'],
+];
 </script>
 
 <style module>
@@ -23,5 +53,11 @@ import TypeScale from './TypeScale.vue';
   color: var(--base--text);
   min-height: 100%;
   padding: 20px;
+}
+
+.buttons {
+  display: grid;
+  gap: var(--spacing-xl);
+  grid-template-columns: repeat(4, 1fr);
 }
 </style>

--- a/codex-ui/src/styles/themes/classic.pcss
+++ b/codex-ui/src/styles/themes/classic.pcss
@@ -8,7 +8,7 @@
   --classic--bg-secondary-hover: #3b3c40;
   --classic--bg-input: #e70037;
   --classic--border: #363940;
-  --classic--solid-hover: #183b65;
+  --classic--solid-hover: #0075ff;
   --classic--solid: #1c84ff;
   --classic--text-secondary: #94979a;
   --classic--text: #f5f5f5;

--- a/codex-ui/src/styles/themes/classic.pcss
+++ b/codex-ui/src/styles/themes/classic.pcss
@@ -1,5 +1,5 @@
-body[theme-base='classic'],
-body[theme-accent='classic'] {
+[theme-base='classic'],
+[theme-accent='classic'] {
   /**
   * Classic Dark Colors
   */
@@ -18,7 +18,7 @@ body[theme-accent='classic'] {
 /**
 * Set up the colors for theme Classic
 */
-body[theme-base='classic'] {
+[theme-base='classic'] {
   --base--bg-primary: var(--classic--bg-primary);
   --base--bg-secondary: var(--classic--bg-secondary);
   --base--bg-secondary-hover: var(--classic--bg-secondary-hover);
@@ -31,7 +31,7 @@ body[theme-base='classic'] {
   --base--text-solid-foreground: var(--classic--text-solid-foreground);
 }
 
-body[theme-accent='classic'] {
+[theme-accent='classic'] {
   --accent--bg-primary: var(--classic--bg-primary);
   --accent--bg-secondary: var(--classic--bg-secondary);
   --accent--bg-secondary-hover: var(--classic--bg-secondary-hover);

--- a/codex-ui/src/styles/themes/crimson.pcss
+++ b/codex-ui/src/styles/themes/crimson.pcss
@@ -1,5 +1,5 @@
-body[theme-base='crimson'],
-body[theme-accent='crimson'] {
+[theme-base='crimson'],
+[theme-accent='crimson'] {
   /**
     * Crimson Dark Colors
     */
@@ -19,7 +19,7 @@ body[theme-accent='crimson'] {
 /**
 * Set up color for the theme Crimson
 */
-body[theme-base='crimson'] {
+[theme-base='crimson'] {
   --base--bg-primary: var(--crimson--bg-primary);
   --base--bg-secondary: var(--crimson--bg-secondary);
   --base--bg-secondary-hover: var(--crimson--bg-secondary-hover);
@@ -33,7 +33,7 @@ body[theme-base='crimson'] {
   --base--text-solid-foreground: var(--crimson--text-solid-foreground);
 }
 
-body[theme-accent='crimson'] {
+[theme-accent='crimson'] {
   --accent--bg-primary: var(--crimson--bg-primary);
   --accent--bg-secondary: var(--crimson--bg-secondary);
   --accent--bg-secondary-hover: var(--crimson--bg-secondary-hover);

--- a/codex-ui/src/styles/themes/grass.pcss
+++ b/codex-ui/src/styles/themes/grass.pcss
@@ -1,5 +1,5 @@
-body[theme-base='grass'],
-body[theme-accent='grass'] {
+[theme-base='grass'],
+[theme-accent='grass'] {
   /**
     * Grass Dark Colors
     */
@@ -19,7 +19,7 @@ body[theme-accent='grass'] {
 /**
 * Set up colors for the theme Grass
 */
-body[theme-base='grass'] {
+[theme-base='grass'] {
   --base--bg-primary: var(--grass--bg-primary);
   --base--bg-secondary: var(--grass--bg-secondary);
   --base--bg-secondary-hover: var(--grass--bg-secondary-hover);
@@ -33,7 +33,7 @@ body[theme-base='grass'] {
   --base--text-solid-foreground: var(--grass--text-solid-foreground);
 }
 
-body[theme-accent='grass'] {
+[theme-accent='grass'] {
   --accent--bg-primary: var(--grass--bg-primary);
   --accent--bg-secondary: var(--grass--bg-secondary);
   --accent--bg-secondary-hover: var(--grass--bg-secondary-hover);

--- a/codex-ui/src/styles/themes/red.pcss
+++ b/codex-ui/src/styles/themes/red.pcss
@@ -1,5 +1,5 @@
-body[theme-base='red'],
-body[theme-accent='red'] {
+[theme-base='red'],
+[theme-accent='red'] {
   /**
    * Red Dark Colors
    */
@@ -19,7 +19,7 @@ body[theme-accent='red'] {
 /**
  * Set up colors for the theme Red
  */
-body[theme-base='red'] {
+[theme-base='red'] {
   --base--bg-primary: var(--red--bg-primary);
   --base--bg-secondary: var(--red--bg-secondary);
   --base--bg-secondary-hover: var(--red--bg-secondary-hover);
@@ -33,7 +33,7 @@ body[theme-base='red'] {
   --base--text-solid-foreground: var(--red--text-solid-foreground);
 }
 
-body[theme-accent='red'] {
+[theme-accent='red'] {
   --accent--bg-primary: var(--red--bg-primary);
   --accent--bg-secondary: var(--red--bg-secondary);
   --accent--bg-secondary-hover: var(--red--bg-secondary-hover);

--- a/codex-ui/src/styles/themes/violet.pcss
+++ b/codex-ui/src/styles/themes/violet.pcss
@@ -1,5 +1,5 @@
-body[theme-base='violet'],
-body[theme-accent='violet'] {
+[theme-base='violet'],
+[theme-accent='violet'] {
   /**
    * Violet Dark Colors
    */
@@ -19,7 +19,7 @@ body[theme-accent='violet'] {
 /**
  * Set up colors for the theme Violet
  */
-body[theme-base='violet'] {
+[theme-base='violet'] {
   --base--bg-primary: var(--violet--bg-primary);
   --base--bg-secondary: var(--violet--bg-secondary);
   --base--bg-secondary-hover: var(--violet--bg-secondary-hover);
@@ -33,7 +33,7 @@ body[theme-base='violet'] {
   --base--text-solid-foreground: var(--violet--text-solid-foreground);
 }
 
-body[theme-accent='violet'] {
+[theme-accent='violet'] {
   --accent--bg-primary: var(--violet--bg-primary);
   --accent--bg-secondary: var(--violet--bg-secondary);
   --accent--bg-secondary-hover: var(--violet--bg-secondary-hover);

--- a/codex-ui/src/vue/button/Button.vue
+++ b/codex-ui/src/vue/button/Button.vue
@@ -1,25 +1,63 @@
 <template>
-  <div>
-    <button :class="[$style.button, `${$style.button}--${size}`, 'text-ui-base-medium']">
-      <slot />
-    </button>
-  </div>
+  <button
+    :class="[$style.button, `${$style.button}--${size}`, `${$style.button}--${style}`, 'text-ui-base-medium']"
+    :theme-accent="style === 'destructive' ? 'red' : undefined"
+  >
+    <slot />
+  </button>
 </template>
 
 <script setup lang="ts">
-import { defineProps } from 'vue';
+import { computed, defineProps } from 'vue';
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     /**
      * The size of the button
      */
     size?: 'small' | 'medium' | 'large';
+
+    /**
+     * Whether the button is a secondary button
+     */
+    secondary?: boolean;
+
+    /**
+     * Whether the button is disabled
+     */
+    disabled?: boolean;
+
+    /**
+     * Whether the button is responsible for a destructive action
+     */
+    destructive?: boolean;
   }>(),
   {
     size: 'medium',
+    secondary: false,
+    disabled: false,
+    destructive: false,
   }
 );
+
+/**
+ * Button style: primary (default), secondary, destructive, disabled
+ */
+const style = computed(() => {
+  if (props.disabled) {
+    return 'disabled';
+  }
+
+  if (props.secondary) {
+    return 'secondary';
+  }
+
+  if (props.destructive) {
+    return 'destructive';
+  }
+
+  return 'primary';
+});
 </script>
 
 <style lang="postcss" module>
@@ -27,12 +65,17 @@ withDefaults(
   border: 0;
   outline: 0;
   font-family: inherit;
+  cursor: pointer;
 
   --padding: 0 0;
   --radius: 0;
   --color: var(--base--text-solid-foreground);
   --bg: var(--base--solid);
+  --bg-hover: var(--base--solid-hover);
 
+  /**
+   * Sizes
+   */
   &--small {
     --padding: var(--spacing-xxs) var(--spacing-s);
     --radius: var(--radius-m);
@@ -48,9 +91,38 @@ withDefaults(
     --radius: var(--radius-ml);
   }
 
+  /**
+   * Styles
+   */
+  &--primary {
+    --bg: var(--base--solid);
+    --bg-hover: var(--base--solid-hover);
+  }
+
+  &--secondary {
+    --bg: var(--base--bg-secondary);
+    --bg-hover: var(--base--bg-secondary-hover);
+  }
+
+  &--disabled {
+    --bg: var(--base--bg-secondary);
+    --bg-hover: var(--base--bg-secondary);
+    --color: var(--base--text-secondary);
+    cursor: not-allowed;
+  }
+
+  &--destructive {
+    --bg: var(--accent--solid);
+    --bg-hover: var(--accent--solid-hover);
+  }
+
   padding: var(--padding);
   border-radius: var(--radius);
   background-color: var(--bg);
   color: var(--color);
+
+  &:hover {
+    background-color: var(--bg-hover);
+  }
 }
 </style>

--- a/codex-ui/src/vue/button/Button.vue
+++ b/codex-ui/src/vue/button/Button.vue
@@ -72,6 +72,7 @@ const style = computed(() => {
   --color: var(--base--text-solid-foreground);
   --bg: var(--base--solid);
   --bg-hover: var(--base--solid-hover);
+  --border-color: transparent;
 
   /**
    * Sizes
@@ -102,6 +103,7 @@ const style = computed(() => {
   &--secondary {
     --bg: var(--base--bg-secondary);
     --bg-hover: var(--base--bg-secondary-hover);
+    --border-color: var(--base--border);
   }
 
   &--disabled {
@@ -120,6 +122,7 @@ const style = computed(() => {
   border-radius: var(--radius);
   background-color: var(--bg);
   color: var(--color);
+  box-shadow: inset 0 0 0 1px var(--border-color);
 
   &:hover {
     background-color: var(--bg-hover);


### PR DESCRIPTION
- Button can have one of 3 styles: `primary` (default), `secondary`, `destructive`
- Button can have one of 3 states: `default`, `hover`, `disabled`
- Color schemas now can be used not only for `body`, but for any element. `Red` scheme is used for `destructive` style

![image](https://github.com/codex-team/notes.web/assets/3684889/c8192388-15ad-4869-8244-cfa57e085fc3)
