### PR TITLE
feat(ui): Input size

### DIFF
--- a/codex-ui/dev/Playground.vue
+++ b/codex-ui/dev/Playground.vue
@@ -2,11 +2,40 @@
   <div :class="$style.playground">
     <Heading :level="1">Playground</Heading>
     <Heading :level="3">Buttons</Heading>
-    <Button size="small">Button</Button><br />
-    <Button>Button</Button><br />
-    <Button size="large">Button</Button><br />
+    <div :class="$style.buttons">
+      <div v-for="button in buttons">
+        <Button
+          :size="button[0]"
+          :style="button[1]"
+          :disabled="button[1] === 'disabled'"
+        >
+          Button
+        </Button>
+      </div>
+    </div>
+
     <Heading :level="3"> Input </Heading>
-    <Input text="Enter email" />
+    <Input
+      text="Enter email"
+      size="small"
+    />
+    <br />
+    <Input
+      text="Enter email"
+      size="medium"
+    />
+    <br />
+    <Input
+      text="Enter email"
+      size="large"
+    />
+    <br />
+    <Input
+      text="Enter email"
+      size="large"
+      disabled
+    />
+
     <Heading :level="3"> Type Scale </Heading>
     <TypeScale />
   </div>
@@ -15,6 +44,24 @@
 <script setup lang="ts">
 import { Button, Heading, Input } from '../src/vue';
 import TypeScale from './TypeScale.vue';
+
+/**
+ * Button samples in different states
+ */
+const buttons = [
+  ['small'],
+  ['small', 'secondary'],
+  ['small', 'destructive'],
+  ['small', 'disabled'],
+  ['medium'],
+  ['medium', 'secondary'],
+  ['medium', 'destructive'],
+  ['medium', 'disabled'],
+  ['large'],
+  ['large', 'secondary'],
+  ['large', 'destructive'],
+  ['large', 'disabled'],
+];
 </script>
 
 <style module>
@@ -23,5 +70,11 @@ import TypeScale from './TypeScale.vue';
   color: var(--base--text);
   min-height: 100%;
   padding: 20px;
+}
+
+.buttons {
+  display: grid;
+  gap: var(--spacing-xl);
+  grid-template-columns: repeat(4, 1fr);
 }
 </style>

--- a/codex-ui/src/vue/button/Button.vue
+++ b/codex-ui/src/vue/button/Button.vue
@@ -7,19 +7,42 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps } from 'vue';
+import { computed, defineProps } from 'vue';
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     /**
      * The size of the button
      */
     size?: 'small' | 'medium' | 'large';
+
+    /**
+     * The style of the button
+     */
+    style?: 'primary' | 'secondary' | 'destructive';
+
+    /**
+     * Whether the button is disabled
+     */
+    disabled?: boolean;
   }>(),
   {
     size: 'medium',
+    style: 'primary',
+    disabled: false,
   }
 );
+
+/**
+ * Button style: primary (default), secondary, destructive, disabled
+ */
+const style = computed(() => {
+  if (props.disabled) {
+    return 'disabled';
+  }
+
+  return props.style;
+});
 </script>
 
 <style lang="postcss" module>

--- a/codex-ui/src/vue/input/Input.vue
+++ b/codex-ui/src/vue/input/Input.vue
@@ -1,8 +1,9 @@
 <template>
   <div>
     <input
-      :class="$style.input"
+      :class="[$style.input, `${$style.input}--${size}`, 'text-ui-base']"
       :value="props.text"
+      :disabled="props.disabled"
     />
   </div>
 </template>
@@ -10,12 +11,28 @@
 <script setup lang="ts">
 import { defineProps } from 'vue';
 
-const props = defineProps<{
-  /**
-   * The text to display on the input
-   */
-  text: string;
-}>();
+const props = withDefaults(
+  defineProps<{
+    /**
+     * The text to display on the input
+     */
+    text: string;
+
+    /**
+     * The size of the input
+     */
+    size?: 'small' | 'medium' | 'large';
+
+    /**
+     * Whether the input is disabled
+     */
+    disabled?: boolean;
+  }>(),
+  {
+    size: 'medium',
+    disabled: false,
+  }
+);
 </script>
 
 <style lang="postcss" module>
@@ -24,9 +41,34 @@ const props = defineProps<{
   border: 0;
   outline: 0;
   color: var(--base--text);
-  padding: var(--spacing-m) var(--spacing-ml);
-  border-radius: var(--radius-ml);
   font-size: inherit;
   font-family: inherit;
+
+  --padding: 0 0;
+
+  /**
+   * Sizes
+   */
+  &--small {
+    --padding: var(--spacing-xxs) var(--spacing-s);
+    --radius: var(--radius-m);
+  }
+
+  &--medium {
+    --padding: var(--spacing-s) var(--spacing-m);
+    --radius: var(--radius-m);
+  }
+
+  &--large {
+    --padding: var(--spacing-m) var(--spacing-l);
+    --radius: var(--radius-ml);
+  }
+
+  &[disabled] {
+    color: var(--base--text-secondary);
+  }
+
+  padding: var(--padding);
+  border-radius: var(--radius);
 }
 </style>


### PR DESCRIPTION
- Input sizes added: `small`, `medium`, `large`
- Input now can be disabled
- Button style now should be passed through the `style=secondary` instead of `secondary`. And other style as well. This change prevents possible style multiplication (`secondary destructive`)


![image](https://github.com/codex-team/notes.web/assets/3684889/0a85f4d0-e127-45e4-84f3-028605f36f31)
