### PR TITLE
feat(ui): form field

### DIFF
--- a/codex-ui/dev/Playground.vue
+++ b/codex-ui/dev/Playground.vue
@@ -41,25 +41,25 @@
     />
 
     <Heading :level="3">Form Section</Heading>
-    <FormSection
-      v-model="formSectionValue"
-      :value="formSectionValue"
+    <FormField
+      v-model="formFieldValue"
+      :value="formFieldValue"
       title="Title"
       caption="Will be visible in Tools list"
       size="small"
     />
     <br />
-    <FormSection
-      v-model="formSectionValue"
-      :value="formSectionValue"
+    <FormField
+      v-model="formFieldValue"
+      :value="formFieldValue"
       title="Title"
       caption="Will be visible in Tools list"
       size="medium"
     />
     <br />
-    <FormSection
-      v-model="formSectionValue"
-      :value="formSectionValue"
+    <FormField
+      v-model="formFieldValue"
+      :value="formFieldValue"
       title="Title"
       caption="Will be visible in Tools list"
       size="large"
@@ -72,10 +72,10 @@
 
 <script setup lang="ts">
 import { ref } from 'vue';
-import { Button, Heading, Input, FormSection } from '../src/vue';
+import { Button, Heading, Input, FormField } from '../src/vue';
 import TypeScale from './TypeScale.vue';
 
-const formSectionValue = ref('Heading');
+const formFieldValue = ref('Heading');
 
 /**
  * Button samples in different states

--- a/codex-ui/dev/Playground.vue
+++ b/codex-ui/dev/Playground.vue
@@ -40,7 +40,7 @@
       disabled
     />
 
-    <Heading :level="3">Form Section</Heading>
+    <Heading :level="3">Form Field</Heading>
     <FormField
       v-model="formFieldValue"
       :value="formFieldValue"

--- a/codex-ui/dev/Playground.vue
+++ b/codex-ui/dev/Playground.vue
@@ -17,24 +17,52 @@
 
     <Heading :level="3"> Input </Heading>
     <Input
-      text="Enter email"
+      value="Enter email"
       size="small"
     />
     <br />
+    <br />
     <Input
-      text="Enter email"
+      value="Enter email"
       size="medium"
     />
     <br />
+    <br />
     <Input
-      text="Enter email"
+      value="Enter email"
       size="large"
     />
     <br />
+    <br />
     <Input
-      text="Enter email"
+      value="Enter email"
       size="large"
       disabled
+    />
+
+    <Heading :level="3">Form Section</Heading>
+    <FormSection
+      v-model="formSectionValue"
+      :value="formSectionValue"
+      title="Title"
+      caption="Will be visible in Tools list"
+      size="small"
+    />
+    <br />
+    <FormSection
+      v-model="formSectionValue"
+      :value="formSectionValue"
+      title="Title"
+      caption="Will be visible in Tools list"
+      size="medium"
+    />
+    <br />
+    <FormSection
+      v-model="formSectionValue"
+      :value="formSectionValue"
+      title="Title"
+      caption="Will be visible in Tools list"
+      size="large"
     />
 
     <Heading :level="3"> Type Scale </Heading>
@@ -43,8 +71,11 @@
 </template>
 
 <script setup lang="ts">
-import { Button, Heading, Input } from '../src/vue';
+import { ref } from 'vue';
+import { Button, Heading, Input, FormSection } from '../src/vue';
 import TypeScale from './TypeScale.vue';
+
+const formSectionValue = ref('Heading');
 
 /**
  * Button samples in different states

--- a/codex-ui/dev/index.html
+++ b/codex-ui/dev/index.html
@@ -1,3 +1,6 @@
+<head>
+  <title>Codex UI</title>
+</head>
 <body
   theme-base="classic"
   theme-accent="classic"

--- a/codex-ui/src/vue/form/Field.vue
+++ b/codex-ui/src/vue/form/Field.vue
@@ -1,16 +1,16 @@
 <template>
-  <div :class="[$style['form-section'], `${$style['form-section']}--${size}`]">
-    <div :class="[$style['form-section-title'], 'text-ui-footnote']">
+  <div :class="[$style['field'], `${$style['field']}--${size}`]">
+    <div :class="[$style['field-title'], 'text-ui-footnote']">
       {{ title }}
     </div>
-    <div :class="$style['form-section-field']">
+    <div :class="$style['field-field']">
       <Input
         :size="size"
         :disabled="disabled"
         v-model="model"
         :value="value"
       />
-      <div :class="[$style['form-section-caption'], 'text-ui-subtle']">
+      <div :class="[$style['field-caption'], 'text-ui-subtle']">
         {{ caption }}
       </div>
     </div>
@@ -18,7 +18,6 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue';
 import Input from '../input/Input.vue';
 
 const props = withDefaults(
@@ -29,7 +28,7 @@ const props = withDefaults(
     value?: string;
 
     /**
-     * Form section title
+     * Form field title
      * Will be displayed as a heading
      */
     title: string;
@@ -41,12 +40,12 @@ const props = withDefaults(
     caption?: string;
 
     /**
-     * The size of the form section
+     * The size of the form field
      */
     size?: 'small' | 'medium' | 'large';
 
     /**
-     * Whether the form section is disabled
+     * Whether the form field is disabled
      */
     disabled?: boolean;
   }>(),
@@ -62,7 +61,7 @@ const model = defineModel();
 </script>
 
 <style module>
-.form-section {
+.field {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-xs);

--- a/codex-ui/src/vue/form/Section.vue
+++ b/codex-ui/src/vue/form/Section.vue
@@ -1,0 +1,90 @@
+<template>
+  <div :class="[$style['form-section'], `${$style['form-section']}--${size}`]">
+    <div :class="[$style['form-section-title'], 'text-ui-footnote']">
+      {{ title }}
+    </div>
+    <div :class="$style['form-section-field']">
+      <Input
+        :size="size"
+        :disabled="disabled"
+        v-model="model"
+        :value="value"
+      />
+      <div :class="[$style['form-section-caption'], 'text-ui-subtle']">
+        {{ caption }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { Input } from '@/vue';
+
+const props = withDefaults(
+  defineProps<{
+    /**
+     * Input value
+     */
+    value?: string;
+
+    /**
+     * Form section title
+     * Will be displayed as a heading
+     */
+    title: string;
+
+    /**
+     * The size of the input
+     * Will be passed to the input component
+     */
+    caption?: string;
+
+    /**
+     * The size of the form section
+     */
+    size?: 'small' | 'medium' | 'large';
+
+    /**
+     * Whether the form section is disabled
+     */
+    disabled?: boolean;
+  }>(),
+  {
+    value: '',
+    caption: '',
+    size: 'medium',
+    disabled: false,
+  }
+);
+
+const model = defineModel();
+</script>
+
+<style module>
+.form-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+
+  --h-padding: var(--spacing-m);
+
+  &--small {
+    --h-padding: var(--spacing-s);
+  }
+
+  &--medium {
+    --h-padding: var(--spacing-m);
+  }
+
+  &--large {
+    --h-padding: var(--spacing-l);
+  }
+
+  &-title,
+  &-caption {
+    padding-top: var(--spacing-xs);
+    padding-inline: var(--h-padding);
+  }
+}
+</style>

--- a/codex-ui/src/vue/form/Section.vue
+++ b/codex-ui/src/vue/form/Section.vue
@@ -19,7 +19,7 @@
 
 <script setup lang="ts">
 import { onMounted } from 'vue';
-import { Input } from '@/vue';
+import Input from '../input/Input.vue';
 
 const props = withDefaults(
   defineProps<{

--- a/codex-ui/src/vue/index.ts
+++ b/codex-ui/src/vue/index.ts
@@ -1,6 +1,6 @@
 import Button from './button/Button.vue';
 import Input from './input/Input.vue';
 import Heading from './heading/Heading.vue';
-import FormSection from './form/Section.vue';
+import FormField from './form/Field.vue';
 
-export { Button, Input, Heading, FormSection };
+export { Button, Input, Heading, FormField };

--- a/codex-ui/src/vue/index.ts
+++ b/codex-ui/src/vue/index.ts
@@ -1,5 +1,6 @@
 import Button from './button/Button.vue';
 import Input from './input/Input.vue';
 import Heading from './heading/Heading.vue';
+import FormSection from './form/Section.vue';
 
-export { Button, Input, Heading };
+export { Button, Input, Heading, FormSection };

--- a/codex-ui/src/vue/input/Input.vue
+++ b/codex-ui/src/vue/input/Input.vue
@@ -1,22 +1,20 @@
 <template>
-  <div>
-    <input
-      :class="[$style.input, `${$style.input}--${size}`, 'text-ui-base']"
-      :value="props.text"
-      :disabled="props.disabled"
-    />
-  </div>
+  <input
+    :class="[$style.input, `${$style.input}--${size}`, 'text-ui-base']"
+    :disabled="props.disabled"
+    v-model="model"
+  />
 </template>
 
 <script setup lang="ts">
-import { defineProps } from 'vue';
+import { onMounted } from 'vue';
 
 const props = withDefaults(
   defineProps<{
     /**
      * The text to display on the input
      */
-    text: string;
+    value?: string;
 
     /**
      * The size of the input
@@ -29,10 +27,17 @@ const props = withDefaults(
     disabled?: boolean;
   }>(),
   {
+    value: '',
     size: 'medium',
     disabled: false,
   }
 );
+
+const model = defineModel();
+
+onMounted(() => {
+  model.value = props.value;
+});
 </script>
 
 <style lang="postcss" module>


### PR DESCRIPTION
- FormField component added
- It support 3 sizes as well as Input and Button: `small`, `medium`, `large`
- Input component now has the `value` prop instead of `text`
- `v-model` added to the Input and Form Field components allowing to bind values

![image](https://github.com/codex-team/notes.web/assets/3684889/da613618-8861-4888-9772-ccf508a18c85)
