### PR TITLE
feat(team): change team member role

### DIFF
--- a/src/application/i18n/messages/en.json
+++ b/src/application/i18n/messages/en.json
@@ -26,7 +26,8 @@
     "isPublic": "is note public",
     "revokeHash": "Revoke",
     "team": {
-      "title": "Team"
+      "title": "Team",
+      "canEdit": "Can edit"
     }
   },
   "note": {

--- a/src/application/i18n/messages/en.json
+++ b/src/application/i18n/messages/en.json
@@ -26,8 +26,7 @@
     "isPublic": "is note public",
     "revokeHash": "Revoke",
     "team": {
-      "title": "Team",
-      "canEdit": "Can edit"
+      "title": "Team"
     }
   },
   "note": {

--- a/src/application/i18n/messages/en.json
+++ b/src/application/i18n/messages/en.json
@@ -26,7 +26,11 @@
     "isPublic": "is note public",
     "revokeHash": "Revoke",
     "team": {
-      "title": "Team"
+      "title": "Team",
+      "roles": {
+        "Read": "Reader",
+        "Write": "Writer"
+      }
     }
   },
   "note": {

--- a/src/application/services/useNoteSettings.ts
+++ b/src/application/services/useNoteSettings.ts
@@ -2,6 +2,8 @@ import { ref, type Ref } from 'vue';
 import type NoteSettings from '@/domain/entities/NoteSettings';
 import type { NoteId } from '@/domain/entities/Note';
 import { noteSettingsService } from '@/domain';
+import type { UserId } from '@/domain/entities/User';
+import type { MemberRole } from '@/domain/entities/Team';
 
 /**
  * Note settings hook state
@@ -33,6 +35,15 @@ interface UseNoteSettingsComposableState {
    * @param id - note id
    */
   revokeHash: (id: NoteId) => Promise<void>;
+
+  /**
+   * Patch team member role by user and note id
+   *
+   * @param id - Note id
+   * @param userId - id of the user whose role is to be changed
+   * @param newRole - new role
+   */
+  changeRole: (id: NoteId, userId: UserId, newRole: MemberRole) => Promise<void>;
 }
 
 /**
@@ -79,10 +90,23 @@ export default function (): UseNoteSettingsComposableState {
     }
   };
 
+  /**
+   * Patch team member role by user and note id
+   *
+   * @param id - Note id
+   * @param userId - id of the user whose role is to be changed
+   * @param newRole - new role
+   * @returns updated note settings
+   */
+  const changeRole = async (id: NoteId, userId: UserId, newRole: MemberRole): Promise<void> => {
+    await noteSettingsService.patchMemberRoleByUserId(id, userId, newRole);
+  };
+
   return {
     noteSettings,
     load,
     update,
     revokeHash,
+    changeRole,
   };
 }

--- a/src/domain/entities/Team.ts
+++ b/src/domain/entities/Team.ts
@@ -1,5 +1,17 @@
 import type { User } from './User.js';
 
+export enum MemberRole {
+  /**
+   * Team member can only read notes
+   */
+  Read = 0,
+
+  /**
+   * Team member can read and write notes
+   */
+  Write = 1,
+}
+
 /**
  * Class representing a team entity
  * Team is a relation between note and user, which shows what user can do with note
@@ -14,6 +26,11 @@ export interface TeamMember {
    * Team member user
    */
   user: User;
+
+  /**
+   * Team member role, show what user can do with note
+   */
+  role: MemberRole;
 }
 
 export type Team = TeamMember[];

--- a/src/domain/noteSettings.repository.interface.ts
+++ b/src/domain/noteSettings.repository.interface.ts
@@ -1,5 +1,7 @@
 import type NoteSettings from '@/domain/entities/NoteSettings';
 import type { NoteId } from './entities/Note';
+import type { UserId } from './entities/User';
+import type { MemberRole } from './entities/Team';
 
 /**
  * Repository interface describes the methods that required by domain for its business logic implementation
@@ -30,4 +32,14 @@ export default interface NoteSettingsRepositoryInterface {
    * @returns updated note settings
    */
   regenerateInvitationHash(id: NoteId): Promise<NoteSettings>;
+
+  /**
+   * Patch team member role by user and note id
+   *
+   * @param id - Note id
+   * @param userId - id of the user whose role is to be changed
+   * @param newRole - new role
+   * @returns updated note settings
+   */
+  patchMemberRoleByUserId(id: NoteId, userId: UserId, newRole: MemberRole): Promise<MemberRole>;
 }

--- a/src/domain/noteSettings.repository.interface.ts
+++ b/src/domain/noteSettings.repository.interface.ts
@@ -39,7 +39,6 @@ export default interface NoteSettingsRepositoryInterface {
    * @param id - Note id
    * @param userId - id of the user whose role is to be changed
    * @param newRole - new role
-   * @returns updated note settings
    */
   patchMemberRoleByUserId(id: NoteId, userId: UserId, newRole: MemberRole): Promise<MemberRole>;
 }

--- a/src/domain/noteSettings.service.ts
+++ b/src/domain/noteSettings.service.ts
@@ -2,6 +2,8 @@ import type NoteSettingsRepository from '@/domain/noteSettings.repository.interf
 import type NoteSettings from '@/domain/entities/NoteSettings';
 import type { NoteId } from './entities/Note';
 import NotFoundError from './entities/errors/NotFound';
+import type { UserId } from './entities/User';
+import type { MemberRole } from './entities/Team';
 
 /**
  * Note Service
@@ -85,5 +87,17 @@ export default class NoteService {
     }
 
     return result;
+  }
+
+  /**
+   * Patch team member role by user and note id
+   *
+   * @param id - Note id
+   * @param userId - id of the user whose role is to be changed
+   * @param newRole - new role
+   * @returns updated note settings
+   */
+  public async patchMemberRoleByUserId(id: NoteId, userId: UserId, newRole: MemberRole): Promise<MemberRole> {
+    return await this.noteSettingsRepository.patchMemberRoleByUserId(id, userId, newRole);
   }
 }

--- a/src/domain/noteSettings.service.ts
+++ b/src/domain/noteSettings.service.ts
@@ -95,7 +95,6 @@ export default class NoteService {
    * @param id - Note id
    * @param userId - id of the user whose role is to be changed
    * @param newRole - new role
-   * @returns updated note settings
    */
   public async patchMemberRoleByUserId(id: NoteId, userId: UserId, newRole: MemberRole): Promise<MemberRole> {
     return await this.noteSettingsRepository.patchMemberRoleByUserId(id, userId, newRole);

--- a/src/infrastructure/noteSettings.repository.ts
+++ b/src/infrastructure/noteSettings.repository.ts
@@ -60,7 +60,7 @@ export default class NoteSettingsRepository implements NoteSettingsRepositoryInt
    * @param id - Note id
    * @param userId - id of the user whose role is to be changed
    * @param newRole - new role
-   * @returns { NoteSettings } updated note settings
+   * @returns updated role
    */
   public async patchMemberRoleByUserId(id: NoteId, userId: UserId, newRole: MemberRole): Promise<MemberRole> {
     return await this.transport.patch<MemberRole>(`/note-settings/${id}/team`, { userId, newRole });

--- a/src/infrastructure/noteSettings.repository.ts
+++ b/src/infrastructure/noteSettings.repository.ts
@@ -2,6 +2,8 @@ import type NoteSettingsRepositoryInterface from '@/domain/noteSettings.reposito
 import type NoteSettings from '@/domain/entities/NoteSettings';
 import type NotesApiTransport from '@/infrastructure/transport/notes-api';
 import type { NoteId } from '@/domain/entities/Note';
+import type { MemberRole } from '@/domain/entities/Team';
+import type { UserId } from '@/domain/entities/User';
 
 /**
  * Note settings repository
@@ -50,5 +52,17 @@ export default class NoteSettingsRepository implements NoteSettingsRepositoryInt
    */
   public async regenerateInvitationHash(id: NoteId): Promise<NoteSettings> {
     return await this.transport.patch<NoteSettings>(`/note-settings/${id}/invitation-hash`);
+  }
+
+  /**
+   * Patch team member role by user and note id
+   *
+   * @param id - Note id
+   * @param userId - id of the user whose role is to be changed
+   * @param newRole - new role
+   * @returns { NoteSettings } updated note settings
+   */
+  public async patchMemberRoleByUserId(id: NoteId, userId: UserId, newRole: MemberRole): Promise<MemberRole> {
+    return await this.transport.patch<MemberRole>(`/note-settings/${id}/team`, { userId, newRole });
   }
 }

--- a/src/presentation/components/team/Member.vue
+++ b/src/presentation/components/team/Member.vue
@@ -3,32 +3,25 @@
     <div class="member-name">
       {{ teamMember.user.name || teamMember.user.email }}
     </div>
-    <select>
+    <select
+      v-model="selectedRole"
+      @change="updateMemberRole($event)"
+    >
       <option
-        v-for="(role, index) in stringRoles"
+        v-for="(role, index) in roleOptions"
         :key="index"
-        :selected="teamMember.role == index"
       >
         {{ role }}
       </option>
     </select>
-    <!-- <div v-if="teamMember.id != 1">
-      <Checkbox
-        :checked="teamMember.role === 1"
-        :label="t('noteSettings.team.canEdit')"
-        @update:checked="changeMemberRole"
-      />
-    </div> -->
   </li>
 </template>
 
 <script setup lang="ts">
-import Checkbox from '@/presentation/components/checkbox/Checkbox.vue';
 import { MemberRole, TeamMember } from '@/domain/entities/Team.ts';
-import { useI18n } from 'vue-i18n';
-import useNoteSettings from '@/application/services/useNoteSettings';
 import { NoteId } from '@/domain/entities/Note';
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
+import useNoteSettings from '@/application/services/useNoteSettings';
 
 /**
  * TeamMember props
@@ -44,18 +37,21 @@ const props = defineProps<{
   id: NoteId;
 }>();
 
+const selectedRole = ref(MemberRole[props.teamMember.role]);
+
+const roleOptions = computed(() => Object.values(MemberRole).filter((value) => typeof value === 'string'));
+
 const { changeRole } = useNoteSettings();
 
 /**
- * Change member role
+ * Updates the user role if it has been changed
+ *
+ * @param event
  */
-async function changeMemberRole() {
-  changeRole(props.id, props.teamMember.user.id, props.teamMember.role);
+async function updateMemberRole(event: Event) {
+  changeRole(props.id, props.teamMember.user.id, MemberRole[(event.target as HTMLSelectElement).value as string]);
+  console.log((event.target as HTMLSelectElement).value);
 }
-
-const { t } = useI18n();
-
-const stringRoles = computed(() => Object.values(MemberRole).filter((value) => typeof value === 'string'));
 </script>
 
 <style scoped>

--- a/src/presentation/components/team/Member.vue
+++ b/src/presentation/components/team/Member.vue
@@ -3,21 +3,47 @@
     <div class="member-name">
       {{ teamMember.user.name }}
     </div>
+    <div v-if="teamMember.id != 1">
+      <Checkbox
+        :checked="teamMember.role === 1"
+        :label="t('noteSettings.team.canEdit')"
+        @update:checked="changeMemberRole"
+      />
+    </div>
   </li>
 </template>
 
 <script setup lang="ts">
+import Checkbox from '@/presentation/components/checkbox/Checkbox.vue';
 import { TeamMember } from '@/domain/entities/Team.ts';
+import { useI18n } from 'vue-i18n';
+import useNoteSettings from '@/application/services/useNoteSettings';
+import { NoteId } from '@/domain/entities/Note';
 
 /**
  * TeamMember props
  */
-defineProps<{
+const props = defineProps<{
   /**
    * Team member data
    */
   teamMember: TeamMember;
+  /**
+   * Id of the current note
+   */
+  id: NoteId;
 }>();
+
+const { changeRole } = useNoteSettings();
+
+/**
+ * Change member role
+ */
+async function changeMemberRole() {
+  changeRole(props.id, props.teamMember.user.id, props.teamMember.role);
+}
+
+const { t } = useI18n();
 </script>
 
 <style scoped>

--- a/src/presentation/components/team/Member.vue
+++ b/src/presentation/components/team/Member.vue
@@ -39,7 +39,7 @@ const props = defineProps<{
   /**
    * Id of the current note
    */
-  id: NoteId;
+  noteId: NoteId;
 }>();
 
 const selectedRole = ref(MemberRole[props.teamMember.role]);
@@ -58,7 +58,7 @@ const { t } = useI18n();
  * @param newRole - new member role
  */
 async function updateMemberRole(newRole: string) {
-  changeRole(props.id, props.teamMember.user.id, MemberRole[newRole as keyof typeof MemberRole]);
+  changeRole(props.noteId, props.teamMember.user.id, MemberRole[newRole as keyof typeof MemberRole]);
 }
 </script>
 

--- a/src/presentation/components/team/Member.vue
+++ b/src/presentation/components/team/Member.vue
@@ -3,25 +3,28 @@
     <div class="member-name">
       {{ teamMember.user.name || teamMember.user.email }}
     </div>
-    <select
-      v-model="selectedRole"
-      @change="updateMemberRole($event)"
-    >
-      <option
-        v-for="(role, index) in roleOptions"
-        :key="index"
+    <div v-if="teamMember.user.id != user?.id">
+      <select
+        v-model="selectedRole"
+        @change="updateMemberRole(selectedRole)"
       >
-        {{ role }}
-      </option>
-    </select>
+        <option
+          v-for="(role, index) in roleOptions"
+          :key="index"
+        >
+          {{ role }}
+        </option>
+      </select>
+    </div>
   </li>
 </template>
 
 <script setup lang="ts">
 import { MemberRole, TeamMember } from '@/domain/entities/Team.ts';
-import { NoteId } from '@/domain/entities/Note';
+import { NoteId } from '@/domain/entities/Note.ts';
 import { computed, ref } from 'vue';
-import useNoteSettings from '@/application/services/useNoteSettings';
+import useNoteSettings from '@/application/services/useNoteSettings.ts';
+import { useAppState } from '@/application/services/useAppState';
 
 /**
  * TeamMember props
@@ -43,14 +46,15 @@ const roleOptions = computed(() => Object.values(MemberRole).filter((value) => t
 
 const { changeRole } = useNoteSettings();
 
+const { user } = useAppState();
+
 /**
  * Updates the user role if it has been changed
  *
- * @param event
+ * @param newRole - new member role
  */
-async function updateMemberRole(event: Event) {
-  changeRole(props.id, props.teamMember.user.id, MemberRole[(event.target as HTMLSelectElement).value as string]);
-  console.log((event.target as HTMLSelectElement).value);
+async function updateMemberRole(newRole: string) {
+  changeRole(props.id, props.teamMember.user.id, MemberRole[newRole as keyof typeof MemberRole]);
 }
 </script>
 

--- a/src/presentation/components/team/Member.vue
+++ b/src/presentation/components/team/Member.vue
@@ -3,22 +3,32 @@
     <div class="member-name">
       {{ teamMember.user.name || teamMember.user.email }}
     </div>
-    <div v-if="teamMember.id != 1">
+    <select>
+      <option
+        v-for="(role, index) in stringRoles"
+        :key="index"
+        :selected="teamMember.role == index"
+      >
+        {{ role }}
+      </option>
+    </select>
+    <!-- <div v-if="teamMember.id != 1">
       <Checkbox
         :checked="teamMember.role === 1"
         :label="t('noteSettings.team.canEdit')"
         @update:checked="changeMemberRole"
       />
-    </div>
+    </div> -->
   </li>
 </template>
 
 <script setup lang="ts">
 import Checkbox from '@/presentation/components/checkbox/Checkbox.vue';
-import { TeamMember } from '@/domain/entities/Team.ts';
+import { MemberRole, TeamMember } from '@/domain/entities/Team.ts';
 import { useI18n } from 'vue-i18n';
 import useNoteSettings from '@/application/services/useNoteSettings';
 import { NoteId } from '@/domain/entities/Note';
+import { computed } from 'vue';
 
 /**
  * TeamMember props
@@ -44,6 +54,8 @@ async function changeMemberRole() {
 }
 
 const { t } = useI18n();
+
+const stringRoles = computed(() => Object.values(MemberRole).filter((value) => typeof value === 'string'));
 </script>
 
 <style scoped>

--- a/src/presentation/components/team/Member.vue
+++ b/src/presentation/components/team/Member.vue
@@ -6,7 +6,7 @@
     <div v-if="teamMember.user.id != user?.id">
       <select
         v-model="selectedRole"
-        @change="updateMemberRole(selectedRole)"
+        @change="updateMemberRole"
       >
         <option
           v-for="(role, index) in roleOptions"
@@ -54,11 +54,9 @@ const { t } = useI18n();
 
 /**
  * Updates the user role if it has been changed
- *
- * @param newRole - new member role
  */
-async function updateMemberRole(newRole: string) {
-  changeRole(props.noteId, props.teamMember.user.id, MemberRole[newRole as keyof typeof MemberRole]);
+async function updateMemberRole() {
+  changeRole(props.noteId, props.teamMember.user.id, MemberRole[selectedRole.value as keyof typeof MemberRole]);
 }
 </script>
 

--- a/src/presentation/components/team/Member.vue
+++ b/src/presentation/components/team/Member.vue
@@ -11,8 +11,9 @@
         <option
           v-for="(role, index) in roleOptions"
           :key="index"
+          :value="role"
         >
-          {{ role }}
+          {{ t(`noteSettings.team.roles.${role}`) }}
         </option>
       </select>
     </div>
@@ -25,6 +26,7 @@ import { NoteId } from '@/domain/entities/Note.ts';
 import { computed, ref } from 'vue';
 import useNoteSettings from '@/application/services/useNoteSettings.ts';
 import { useAppState } from '@/application/services/useAppState';
+import { useI18n } from 'vue-i18n';
 
 /**
  * TeamMember props
@@ -47,6 +49,8 @@ const roleOptions = computed(() => Object.values(MemberRole).filter((value) => t
 const { changeRole } = useNoteSettings();
 
 const { user } = useAppState();
+
+const { t } = useI18n();
 
 /**
  * Updates the user role if it has been changed

--- a/src/presentation/components/team/Team.vue
+++ b/src/presentation/components/team/Team.vue
@@ -1,23 +1,34 @@
 <template>
-  <h1>{{ $t('noteSettings.team.title') }}</h1>
+  <h1>{{ t('noteSettings.team.title') }}</h1>
   <ul
     v-for="member in team"
     :key="member.id"
   >
-    <Member :team-member="member" />
+    <Member
+      :id="id"
+      :team-member="member"
+    />
   </ul>
 </template>
 
 <script setup lang="ts">
 import { Team } from '@/domain/entities/Team';
 import Member from './Member.vue';
+import { useI18n } from 'vue-i18n';
+import { NoteId } from '@/domain/entities/Note';
 
 defineProps<{
   /**
    * Team of the current note
    */
   team: Team;
+  /**
+   * Id of the current note
+   */
+  id: NoteId;
 }>();
+
+const { t } = useI18n();
 </script>
 
 <style scoped></style>

--- a/src/presentation/components/team/Team.vue
+++ b/src/presentation/components/team/Team.vue
@@ -5,7 +5,7 @@
     :key="member.id"
   >
     <Member
-      :id="id"
+      :note-id="noteId"
       :team-member="member"
     />
   </ul>
@@ -25,7 +25,7 @@ defineProps<{
   /**
    * Id of the current note
    */
-  id: NoteId;
+  noteId: NoteId;
 }>();
 
 const { t } = useI18n();

--- a/src/presentation/pages/NoteSettings.vue
+++ b/src/presentation/pages/NoteSettings.vue
@@ -18,7 +18,7 @@
       @click="regenerateHash"
     />
     <Team
-      :id="id"
+      :note-id="id"
       :team="noteSettings.team"
     />
     <div class="control__button">

--- a/src/presentation/pages/NoteSettings.vue
+++ b/src/presentation/pages/NoteSettings.vue
@@ -17,7 +17,10 @@
       type="primary"
       @click="regenerateHash"
     />
-    <Team :team="noteSettings.team" />
+    <Team
+      :id="id"
+      :team="noteSettings.team"
+    />
     <div class="control__button">
       <Button
         class="header__plus"


### PR DESCRIPTION
Now Note owner can change role of the team members (excluding his role) by using select component. It is not necessary to use the temporary `Save` button to save the data.
![image](https://github.com/codex-team/notes.web/assets/94054053/f1bcfa61-2497-47bc-b791-7a20475b9fc1)
