### PR TITLE
Add running eslint on CI in codex-ui

### DIFF
--- a/.github/workflows/eslint-check.yml
+++ b/.github/workflows/eslint-check.yml
@@ -21,3 +21,12 @@ jobs:
 
       - name: Run ESLint
         run: yarn lint
+
+      - name: Install codex-ui dependencies
+        run: |
+          yarn install
+        working-directory: ./codex-ui
+      
+      - name: Run ESLint on codex-ui
+        run: yarn lint
+        working-directory: ./codex-ui

--- a/codex-ui/package.json
+++ b/codex-ui/package.json
@@ -28,6 +28,8 @@
   "devDependencies": {
     "@types/node": "^20.11.15",
     "@vitejs/plugin-vue": "^5.0.3",
+    "eslint": "^8.51.0",
+    "eslint-config-codex": "^1.9.1",
     "postcss-apply": "^0.12.0",
     "postcss-hover-media-feature": "^1.0.2",
     "postcss-nested": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2293,6 +2293,8 @@ __metadata:
   dependencies:
     "@types/node": ^20.11.15
     "@vitejs/plugin-vue": ^5.0.3
+    eslint: ^8.51.0
+    eslint-config-codex: ^1.9.1
     postcss-apply: ^0.12.0
     postcss-hover-media-feature: ^1.0.2
     postcss-nested: ^6.0.1


### PR DESCRIPTION
Now Eslint checks codex-ui folder as well as the main app.

![image](https://github.com/codex-team/notes.web/assets/59017579/b15ab3e9-0ae4-47dd-96b6-d7f01a21b862)

Resolves https://github.com/codex-team/notes.web/issues/157
