### PR TITLE
Fix: fix editor not initialising after new note button press

### DIFF
--- a/src/application/services/useUserTools.ts
+++ b/src/application/services/useUserTools.ts
@@ -42,15 +42,19 @@ export function useUserTools(): {
     return downloadedTools;
   }
 
-  watch(userEditorTools, async () => {
-    /**
-     * If user tools are not loaded yet or empty, skip downloading their scripts
-     */
-    if (userEditorTools.value === undefined || userEditorTools.value?.length === 0) {
-      return;
-    }
-    userTools.value = await downloadTools(userEditorTools.value);
-  });
+  watch(
+    userEditorTools,
+    async () => {
+      /**
+       * If user tools are not loaded yet or empty, skip downloading their scripts
+       */
+      if (userEditorTools.value === undefined || userEditorTools.value?.length === 0) {
+        return;
+      }
+      userTools.value = await downloadTools(userEditorTools.value);
+    },
+    { immediate: true }
+  );
 
   return {
     userTools,


### PR DESCRIPTION
We had a problem that editor on new note page was initialising only after page reload because user tools were not updated. Fixed it