### PR TITLE
chore[noteSettings]: added confirmation on note deleting

### DIFF
--- a/src/application/i18n/messages/en.json
+++ b/src/application/i18n/messages/en.json
@@ -28,6 +28,7 @@
     "publish": "Publish Note",
     "revokeHash": "Revoke",
     "deleteNote": "Delete",
+    "noteDeleteConfirmation": "Do you really want to delete this note?",
     "team": {
       "title": "Collaborators",
       "caption": "Who can access the Note even if it’s not published",

--- a/src/presentation/pages/NoteSettings.vue
+++ b/src/presentation/pages/NoteSettings.vue
@@ -79,7 +79,8 @@ async function regenerateHash() {
  * Deletes the note complitely
  */
 async function deleteNote() {
-  if (window.confirm(t('noteSettings.noteDeleteConfirmation'))) {
+  const isConfirmed = window.confirm(t('noteSettings.noteDeleteConfirmation'))
+  if (isConfirmed) {
     deleteNoteById(props.id);
   }
 }

--- a/src/presentation/pages/NoteSettings.vue
+++ b/src/presentation/pages/NoteSettings.vue
@@ -79,7 +79,8 @@ async function regenerateHash() {
  * Deletes the note complitely
  */
 async function deleteNote() {
-  const isConfirmed = window.confirm(t('noteSettings.noteDeleteConfirmation'))
+  const isConfirmed = window.confirm(t('noteSettings.noteDeleteConfirmation'));
+
   if (isConfirmed) {
     deleteNoteById(props.id);
   }

--- a/src/presentation/pages/NoteSettings.vue
+++ b/src/presentation/pages/NoteSettings.vue
@@ -79,7 +79,9 @@ async function regenerateHash() {
  * Deletes the note complitely
  */
 async function deleteNote() {
-  deleteNoteById(props.id);
+  if (window.confirm(t('noteSettings.noteDeleteConfirmation'))) {
+    deleteNoteById(props.id);
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem
User can acidentally delete his note by pressing on delete button in note settings

## Solution
Added confirmation window to make sure the user wants to delete the note
![image](https://github.com/codex-team/notes.web/assets/130844513/2c15f887-1edf-4d97-bb54-d66496f88e9d)
