### PR TITLE
chore(eslint): compatibility with architecture.eslintrc

### DIFF
--- a/.architecture.eslintrc
+++ b/.architecture.eslintrc
@@ -2,6 +2,7 @@
   "plugins": [
     "boundaries"
   ],
+  "ignorePatterns": ["codex-ui"],
   "settings": {
     "boundaries/elements": [
       /**

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,9 +1,22 @@
 import CodeX from 'eslint-config-codex';
+import { FlatCompat } from '@eslint/eslintrc';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// mimic CommonJS variables -- not needed if using CommonJS
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
 /**
  * @todo connect architecture config
  */
 export default [
   ...CodeX,
+  ...compat.extends('.architecture.eslintrc'),
   {
     name: 'notex.api',
     files: ['src/**/*'],

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "vue-router": "^4.2.4"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.1.0",
     "@hawk.so/vite-plugin": "^1.0.2",
     "@types/node": "^20.10.7",
     "@vitejs/plugin-vue": "^4.1.0",

--- a/src/application/services/useNoteSettings.ts
+++ b/src/application/services/useNoteSettings.ts
@@ -44,7 +44,6 @@ interface UseNoteSettingsComposableState {
 
   /**
    * Delete note by it's id
-   *
    * @param id - Note id
    */
   deleteNoteById: (id: NoteId) => Promise<void>;
@@ -117,7 +116,6 @@ export default function (): UseNoteSettingsComposableState {
 
   /**
    * Delete note by it's id
-   *
    * @param id - Note id
    */
   const deleteNoteById = async (id: NoteId): Promise<void> => {

--- a/src/domain/noteSettings.repository.interface.ts
+++ b/src/domain/noteSettings.repository.interface.ts
@@ -40,7 +40,6 @@ export default interface NoteSettingsRepositoryInterface {
 
   /**
    * Delete note by it's id
-   *
    * @param id - Note id
    */
   deleteNote(id: NoteId): Promise<void>;

--- a/src/domain/noteSettings.service.ts
+++ b/src/domain/noteSettings.service.ts
@@ -97,7 +97,6 @@ export default class NoteService {
 
   /**
    * Delete note by it's id
-   *
    * @param id - Note id
    */
   public async deleteNote(id: NoteId): Promise<void> {

--- a/src/infrastructure/noteSettings.repository.ts
+++ b/src/infrastructure/noteSettings.repository.ts
@@ -64,7 +64,6 @@ export default class NoteSettingsRepository implements NoteSettingsRepositoryInt
 
   /**
    * Delete note by it's id
-   *
    * @param id - Note id
    */
   public async deleteNote(id: NoteId): Promise<void> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -895,6 +895,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/eslintrc@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@eslint/eslintrc@npm:3.1.0"
+  dependencies:
+    ajv: ^6.12.4
+    debug: ^4.3.2
+    espree: ^10.0.1
+    globals: ^14.0.0
+    ignore: ^5.2.0
+    import-fresh: ^3.2.1
+    js-yaml: ^4.1.0
+    minimatch: ^3.1.2
+    strip-json-comments: ^3.1.1
+  checksum: b0a9bbd98c8b9e0f4d975b042ff9b874dde722b20834ea2ff46551c3de740d4f10f56c449b790ef34d7f82147cbddfc22b004a43cc885dbc2664bb134766b5e4
+  languageName: node
+  linkType: hard
+
 "@eslint/js@npm:8.57.0":
   version: 8.57.0
   resolution: "@eslint/js@npm:8.57.0"
@@ -4562,6 +4579,7 @@ __metadata:
   resolution: "notes.web@workspace:."
   dependencies:
     "@codexteam/icons": ^0.3.0
+    "@eslint/eslintrc": ^3.1.0
     "@hawk.so/javascript": ^3.0.2
     "@hawk.so/vite-plugin": ^1.0.2
     "@types/node": ^20.10.7


### PR DESCRIPTION
## Problem
Eslint-plugin-boudaries is not compatible with Eslint 9 (check this [issue](https://github.com/javierbrea/eslint-plugin-boundaries/issues/329) for actual information)

Since we migrate to eslint flatconfig format, `architecture.eslintrc` is not a case
also since `.eslintignore` is deprecated we need to specify ignore patterns for `architecture.eslint`

## Solution 
Added FlatCompat plugin to make `architecture.eslint` compatible with flatconfig format

## Bonus
Runned yarn lint:fix