### PR TITLE
fix: return mergedTools as intended

### DIFF
--- a/src/application/services/useMergedTools.ts
+++ b/src/application/services/useMergedTools.ts
@@ -17,7 +17,8 @@ function useMergedTools(tools: Ref<EditorTool[]>): {
    * User notes tools
    */
   const { userEditorTools } = useAppState();
-  const mergedTools = ref<EditorTool[] | undefined>();
+
+  const mergedTools = ref<EditorTool[]>([]);
 
   /**
    * Merge two arrays of tools, removing duplicates
@@ -43,7 +44,7 @@ function useMergedTools(tools: Ref<EditorTool[]>): {
   );
 
   return {
-    tools,
+    tools: mergedTools,
   };
 }
 


### PR DESCRIPTION
Make plugins available again
<img width="727" alt="image" src="https://github.com/codex-team/notes.web/assets/40016207/77be52b3-810f-4561-b0c6-f86624e558a5">
