### PR TITLE
chore(playground): header added, tab component supports link

### DIFF
--- a/codex-ui/dev/Playground.vue
+++ b/codex-ui/dev/Playground.vue
@@ -1,8 +1,22 @@
 <template>
   <div :class="$style.playground">
-    <Heading :level="1">
-      Playground
-    </Heading>
+    <div :class="$style.header">
+      <div :class="$style.logo">
+        CodeX UI
+      </div>
+      <Tabbar
+        :class="$style.headerRight"
+        :tabs="[{
+          title: 'Figma',
+          id: 'figma-button',
+          picture: 'https://cdn.svgporn.com/logos/figma.svg',
+          link: 'https://www.figma.com/design/YmJc2Vqmev25xZgXic5bjL/CodeX-Design-System?node-id=1288-953&t=PhdeYMJcGnLqT4js-0'
+        }]"
+      />
+    </div>
+    <div :class="$style.body">
+      Playground content will be pasted here...
+    </div>
     <Heading :level="3">
       Color Scheme
     </Heading>
@@ -478,7 +492,26 @@ const verticalMenuItems: VerticalMenuItem[] = [
   background-color: var(--base--bg-primary);
   color: var(--base--text);
   min-height: 100%;
-  padding: 20px;
+}
+.header {
+  display: grid;
+  grid-template-columns: auto auto;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--base--border);
+  padding: var(--spacing-xs) var(--spacing-m);
+}
+
+.logo {
+  font-weight: 800;
+  font-size: 16px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  padding: 0 var(--spacing-xs);
+}
+
+.body {
+  padding: var(--spacing-l);
 }
 
 .buttons {

--- a/codex-ui/src/vue/components/tabbar/Tab.types.ts
+++ b/codex-ui/src/vue/components/tabbar/Tab.types.ts
@@ -28,6 +28,11 @@ export interface TabParams {
    * Name of the icon to be diplayed in the left slot, else undefined
    */
   icon?: string;
+
+  /**
+   * If passed, tab will be presented as an hyperlink
+   */
+  link?: string;
 };
 
 export type TabList = TabParams[];

--- a/codex-ui/src/vue/components/tabbar/Tab.vue
+++ b/codex-ui/src/vue/components/tabbar/Tab.vue
@@ -1,6 +1,8 @@
 <template>
-  <div
+  <component
+    :is="link !== undefined ? 'a' : 'div'"
     ref="tabElement"
+    :href="link"
     :class="[
       $style.tab,
       'text-ui-base-medium',
@@ -37,11 +39,12 @@
         @click.stop="$emit('close')"
       />
     </div>
-  </div>
+  </component>
 </template>
 
 <script setup lang="ts">
 import Icon from '../icon/Icon.vue';
+import { TabParams } from './Tab.types';
 
 defineEmits([
   /**
@@ -51,37 +54,7 @@ defineEmits([
 ]);
 
 withDefaults(
-  defineProps<{
-    /**
-     * Unique tab identifier
-     */
-    id: string;
-
-    /**
-     * Name of the tab item
-     */
-    title: string;
-
-    /**
-     * If true we have cross icon on the right
-     */
-    closable?: boolean;
-
-    /**
-     * Current tab state
-     */
-    isActive?: boolean;
-
-    /**
-     * Link to image to be displayed in the left slot, else undefined
-     */
-    picture?: string;
-
-    /**
-     * Name of the icon to be diplayed in the left slot, else undefined
-     */
-    icon?: string;
-  }>(),
+  defineProps<TabParams>(),
   {
     isActive: false,
     picture: undefined,
@@ -99,6 +72,7 @@ withDefaults(
   position: relative;
   display: inline-block;
   min-width: var(--min-width);
+  text-decoration: none;
 
   max-width: max-content;
 


### PR DESCRIPTION
I'm gonna update CodeX UI Playground to make it more comfortable.

This is the first part of the update.

- Playground now has header
- Header has a logo and a Figma link
- Tab component now supports the `link` property to behave like a regular hyperlink.

<img width="1024" alt="image" src="https://github.com/codex-team/notes.web/assets/3684889/aaa5c83a-4ff0-41c5-8452-21ca3d993d0f">
