### PR TITLE
fix: slice on undefined cause any

### DIFF
--- a/src/infrastructure/utils/note.ts
+++ b/src/infrastructure/utils/note.ts
@@ -16,7 +16,7 @@ export function getTitle(content: OutputData): string {
   if (firstNoteBlock.data.text == '') {
     return t('note.untitled');
   } else {
-    return firstNoteBlock.data.text.slice(0, limitCharsForNoteTitle);
+    return firstNoteBlock.data?.text?.slice?.(0, limitCharsForNoteTitle);
   }
 }
 

--- a/src/infrastructure/utils/note.ts
+++ b/src/infrastructure/utils/note.ts
@@ -10,13 +10,15 @@ export function getTitle(content: OutputData): string {
   const firstNoteBlock = content.blocks[0];
   const { t } = useI18n();
 
+  const text: string | undefined = firstNoteBlock.data.text;
+
   /**
    *  If the heading is empty, return 'Untitled'
    */
-  if (firstNoteBlock.data.text == '') {
+  if (text === undefined || text.trim() === '') {
     return t('note.untitled');
   } else {
-    return firstNoteBlock.data?.text?.slice?.(0, limitCharsForNoteTitle);
+    return text?.slice?.(0, limitCharsForNoteTitle);
   }
 }
 


### PR DESCRIPTION
Added checks for the .text property in the block

If block has no text, It should be Untitled

<img width="1478" alt="image" src="https://github.com/codex-team/notes.web/assets/40016207/af0d319e-75b1-4ff2-b067-c431a9b8af31">
