### PR TITLE
feat(settings): User settings page implementation

### DIFF
--- a/codex-ui/dev/pages/components/Fieldset.vue
+++ b/codex-ui/dev/pages/components/Fieldset.vue
@@ -30,9 +30,11 @@
         </template>
       </Row>
     </Section>
-    <Button>
-      button
-    </Button>
+    <div>
+      <Button>
+        button
+      </Button>
+    </div>
   </Fieldset>
 </template>
 

--- a/codex-ui/src/vue/components/form/Fieldset.vue
+++ b/codex-ui/src/vue/components/form/Fieldset.vue
@@ -29,7 +29,6 @@ defineProps<{
 
   &__title {
     padding: var(--v-padding) var(--h-padding);
-    color: var(--base--text);
   }
 
   &__sections {

--- a/codex-ui/src/vue/components/form/Fieldset.vue
+++ b/codex-ui/src/vue/components/form/Fieldset.vue
@@ -28,7 +28,8 @@ defineProps<{
   gap: var(--v-padding);
 
   &__title {
-    padding: var(--v-padding) var(--h-padding) ;
+    padding: var(--v-padding) var(--h-padding);
+    color: var(--base--text);
   }
 
   &__sections {

--- a/src/application/i18n/messages/en.json
+++ b/src/application/i18n/messages/en.json
@@ -3,7 +3,7 @@
   "loadMore":"Load More",
   "auth": {
     "login": "Login",
-    "logout": "Logout"
+    "logout": "👋Logout"
   },
   "header": {
     "buttons": {

--- a/src/application/i18n/messages/en.json
+++ b/src/application/i18n/messages/en.json
@@ -18,7 +18,10 @@
     "uninstallEditorTool": "Uninstall",
     "toolUninstallConfirmation": "Do you really want to delete this tool?",
     "nameCaption": "Will be displayed in collaborators list",
-    "emailCaption": "Used for login"
+    "emailCaption": "Used for login",
+    "name": "name",
+    "email": "email",
+    "general": "General"
   },
   "noteSettings": {
     "title": "Note Settings",

--- a/src/application/i18n/messages/en.json
+++ b/src/application/i18n/messages/en.json
@@ -16,7 +16,9 @@
     "changeTheme": "Change theme",
     "userEditorTools": "User editor tools",
     "uninstallEditorTool": "Uninstall",
-    "toolUninstallConfirmation": "Do you really want to delete this tool?"
+    "toolUninstallConfirmation": "Do you really want to delete this tool?",
+    "nameCaption": "Will be displayed in collaborators list",
+    "emailCaption": "Used for login"
   },
   "noteSettings": {
     "title": "Note Settings",

--- a/src/application/i18n/messages/en.json
+++ b/src/application/i18n/messages/en.json
@@ -19,8 +19,8 @@
     "toolUninstallConfirmation": "Do you really want to delete this tool?",
     "nameCaption": "Will be displayed in collaborators list",
     "emailCaption": "Used for login",
-    "name": "name",
-    "email": "email",
+    "name": "Name",
+    "email": "Email",
     "general": "General"
   },
   "noteSettings": {

--- a/src/presentation/components/header/Header.vue
+++ b/src/presentation/components/header/Header.vue
@@ -5,7 +5,7 @@
       class="header__logo"
     >
       <img
-        src="@/../public/logo.svg"
+        src="/logo.svg"
       >
     </router-link>
     <Tabbar

--- a/src/presentation/pages/Settings.vue
+++ b/src/presentation/pages/Settings.vue
@@ -1,6 +1,8 @@
 <template>
   <div :class="$style['page-header']">
-    <h1>{{ t('userSettings.title') }}</h1>
+    <Heading :level="1">
+      {{ t('userSettings.title') }}
+    </Heading>
   </div>
   <Fieldset title="General">
     <div :class="$style['page-header__general-fields']">
@@ -16,6 +18,11 @@
       >
         <Row :title="user?.email!" />
       </Section>
+      <div>
+        <Button destructive>
+          {{ t('auth.logout') }}
+        </Button>
+      </div>
     </div>
   </Fieldset>
   <h2>{{ t('userSettings.userEditorTools') }}:</h2>
@@ -50,7 +57,7 @@
 
 <script lang="ts" setup>
 import { useI18n } from 'vue-i18n';
-import { Button, Fieldset, Section, Row } from 'codex-ui/vue';
+import { Button, Fieldset, Section, Row, Heading } from 'codex-ui/vue';
 import { IconUnlink } from '@codexteam/icons';
 import { useRouter } from 'vue-router';
 import useAuth from '@/application/services/useAuth';

--- a/src/presentation/pages/Settings.vue
+++ b/src/presentation/pages/Settings.vue
@@ -5,7 +5,7 @@
     </Heading>
   </div>
   <Fieldset :title="t('userSettings.general')">
-    <div :class="$style['page-header__general-fields']">
+    <div :class="$style['general-fields']">
       <Section
         :title="t('userSettings.name')"
         :caption="t('userSettings.nameCaption')"
@@ -119,11 +119,11 @@ async function uninstallClicked(toolId: string) {
     font-weight: 700;
     line-height: 46.2px;
   }
+}
 
-  &__general-fields {
-    display: grid;
-    gap: var(--spacing-xxl);
-  }
+.general-fields {
+  display: grid;
+  gap: var(--spacing-xxl);
 }
 
 .marketplace {

--- a/src/presentation/pages/Settings.vue
+++ b/src/presentation/pages/Settings.vue
@@ -1,5 +1,23 @@
 <template>
-  <h1>{{ t('userSettings.title') }}</h1>
+  <div :class="$style['page-header']">
+    <h1>{{ t('userSettings.title') }}</h1>
+  </div>
+  <Fieldset title="General">
+    <div :class="$style['page-header__general-fields']">
+      <Section
+        title="name"
+        :caption="t('userSettings.nameCaption')"
+      >
+        <Row :title="user?.name!" />
+      </Section>
+      <Section
+        title="email"
+        :caption="t('userSettings.emailCaption')"
+      >
+        <Row :title="user?.email!" />
+      </Section>
+    </div>
+  </Fieldset>
   <h2>{{ t('userSettings.userEditorTools') }}:</h2>
   <ul
     v-for="tool in userEditorTools"
@@ -32,7 +50,7 @@
 
 <script lang="ts" setup>
 import { useI18n } from 'vue-i18n';
-import Button from '../components/button/Button.vue';
+import { Button, Fieldset, Section, Row } from 'codex-ui/vue';
 import { IconUnlink } from '@codexteam/icons';
 import { useRouter } from 'vue-router';
 import useAuth from '@/application/services/useAuth';
@@ -42,7 +60,7 @@ import { useAppState } from '@/application/services/useAppState';
 import { useHead } from 'unhead';
 import useHeader from '@/application/services/useHeader';
 
-const { userEditorTools } = useAppState();
+const { user, userEditorTools } = useAppState();
 const { t } = useI18n();
 const router = useRouter();
 const { logout } = useAuth();
@@ -83,6 +101,23 @@ async function uninstallClicked(toolId: string) {
 
 <style scoped lang="postcss" module>
 @import '@/presentation/styles/typography.pcss';
+
+.page-header {
+  padding: 0 var(--h-padding);
+  gap: var(--spacing-s);
+  color: var(--base--text);
+
+  h1 {
+    font-size: 42px;
+    font-weight: 700;
+    line-height: 46.2px;
+  }
+
+  &__general-fields {
+    display: grid;
+    gap: var(--spacing-xxl);
+  }
+}
 
 .marketplace {
   margin-top: var(--spacing-l);

--- a/src/presentation/pages/Settings.vue
+++ b/src/presentation/pages/Settings.vue
@@ -4,16 +4,16 @@
       {{ t('userSettings.title') }}
     </Heading>
   </div>
-  <Fieldset title="General">
+  <Fieldset :title="t('userSettings.general')">
     <div :class="$style['page-header__general-fields']">
       <Section
-        title="name"
+        :title="t('userSettings.name')"
         :caption="t('userSettings.nameCaption')"
       >
         <Row :title="user?.name!" />
       </Section>
       <Section
-        title="email"
+        :title="t('userSettings.email')"
         :caption="t('userSettings.emailCaption')"
       >
         <Row :title="user?.email!" />


### PR DESCRIPTION
this is the first part of implementation of the `User settings` page 
next time will do list of editor tools in user settings page

![image](https://github.com/codex-team/notes.web/assets/130844513/b7d86c74-31ea-4e6d-a8cb-33986e9a5b09)


- user settings page first step of implementation
- style of the Fieldset component updated
- codestyle of the logo usage in header improved