### PR TITLE
refactor(codex-ui):search in context menu

### DIFF
--- a/codex-ui/dev/pages/components/ContextMenu.vue
+++ b/codex-ui/dev/pages/components/ContextMenu.vue
@@ -9,7 +9,7 @@
   <ContextMenu
     :show-search="true"
     :items="contextMenuItems"
-    :message="'Noting found'"
+    :message="'Nothing found'"
   />
 </template>
 

--- a/codex-ui/dev/pages/components/ContextMenu.vue
+++ b/codex-ui/dev/pages/components/ContextMenu.vue
@@ -43,6 +43,9 @@ const contextMenuItems: ContextMenuItem[] = [
     onActivate: console.log,
   },
   {
+    type: 'separator',
+  },
+  {
     type: 'default',
     title: 'Text',
     icon: 'Text',

--- a/codex-ui/dev/pages/components/ContextMenu.vue
+++ b/codex-ui/dev/pages/components/ContextMenu.vue
@@ -9,7 +9,7 @@
   <ContextMenu
     :show-search="true"
     :items="contextMenuItems"
-    :message="'Nothing found'"
+    message="Nothing found"
   />
 </template>
 

--- a/codex-ui/dev/pages/components/ContextMenu.vue
+++ b/codex-ui/dev/pages/components/ContextMenu.vue
@@ -9,6 +9,7 @@
   <ContextMenu
     :show-search="true"
     :items="contextMenuItems"
+    :message="'Noting found'"
   />
 </template>
 

--- a/codex-ui/dev/pages/components/ContextMenu.vue
+++ b/codex-ui/dev/pages/components/ContextMenu.vue
@@ -9,7 +9,6 @@
   <ContextMenu
     :show-search="true"
     :items="contextMenuItems"
-    message="Nothing found"
   />
 </template>
 

--- a/codex-ui/dev/pages/components/ContextMenu.vue
+++ b/codex-ui/dev/pages/components/ContextMenu.vue
@@ -23,13 +23,12 @@ import { ContextMenu, ContextMenuItem } from '../../../src/vue';
 const contextMenuItems: ContextMenuItem[] = [
   {
     type: 'default',
-    title: 'Header 1',
-    icon: 'H1',
+    title: 'Header',
     // eslint-disable-next-line no-console
     onActivate: console.log,
   },
   {
-    title: 'Header 2',
+    title: 'Header 1',
     icon: 'H1',
     // eslint-disable-next-line no-console
     onActivate: console.log,
@@ -39,14 +38,15 @@ const contextMenuItems: ContextMenuItem[] = [
   },
   {
     type: 'default',
-    title: 'Header 3',
-    icon: 'H1',
+    title: 'Image',
+    icon: 'Picture',
     // eslint-disable-next-line no-console
     onActivate: console.log,
   },
   {
     type: 'default',
-    title: 'Header 3',
+    title: 'Text',
+    icon: 'Text',
     // eslint-disable-next-line no-console
     onActivate: console.log,
   },

--- a/codex-ui/src/vue/components/context-menu/ContextMenu.types.ts
+++ b/codex-ui/src/vue/components/context-menu/ContextMenu.types.ts
@@ -1,7 +1,7 @@
 /**
  * Type of the context menu items - may be default or separator
  */
-export type ContextMenuItem = DefaultItem | SeparatorItem;
+export type ContextMenuItem = DefaultItem | SeparatorItem | MessageItem;
 
 /**
  * Interface representing default context menu item
@@ -37,3 +37,18 @@ export interface SeparatorItem {
    */
   type: 'separator';
 }
+
+/**
+ * Interface representing message item in case if no items were found as a result of the search
+ */
+export interface MessageItem {
+  /**
+   * Type of the item
+   */
+  type: 'message';
+
+  /**
+   * Message what occurs as a result of the search
+   */
+  message: string;
+};

--- a/codex-ui/src/vue/components/context-menu/ContextMenu.vue
+++ b/codex-ui/src/vue/components/context-menu/ContextMenu.vue
@@ -5,22 +5,29 @@
       :class="$style['context-menu__search']"
     >
       <Input
+        v-model="searchTerm"
         icon="Search"
         placeholder="Search"
       />
       <ContextMenuItem :item="separator" />
     </div>
     <div :class="$style['context-menu__scrollable']">
-      <ContextMenuItem
-        v-for="(item, index) in items"
-        :key="index"
-        :item="item"
-      />
+      <template v-if="filteredItems.length > 0">
+        <ContextMenuItem
+          v-for="(item, index) in filteredItems"
+          :key="index"
+          :item="item"
+        />
+      </template>
+      <template v-else>
+        <ContextMenuItem :item="messageItem" />
+      </template>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref, computed } from 'vue';
 import Input from '../input/Input.vue';
 import type { ContextMenuItem as Item } from './ContextMenu.types';
 import ContextMenuItem from './ContextMenuItem.vue';
@@ -30,7 +37,7 @@ import ContextMenuItem from './ContextMenuItem.vue';
  */
 const separator: Item = { type: 'separator' };
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     /**
      * If true, displays the input field for the search
@@ -41,9 +48,42 @@ withDefaults(
      * Array of items for context menu
      */
     items: Item[];
+
+    /**
+     * Message what occurs as a result of the search
+     */
+    message: string;
   }>(),
   { showSearch: false }
 );
+
+/**
+ * User entered word for search
+ */
+const searchTerm = ref('');
+
+const filteredItems = computed(() => {
+  if (searchTerm.value === '') {
+    return props.items;
+  }
+
+  return props.items.filter((item) => {
+    if (item.type === 'separator' || item.type === 'message') {
+      return false;
+    } else {
+      return item.title.toLowerCase().includes(
+        searchTerm.value.toLowerCase());
+    }
+  });
+});
+
+/**
+ * Message for displaying in context menu if result of search is empty
+ */
+const messageItem: Item = {
+  type: 'message',
+  message: props.message,
+};
 
 </script>
 

--- a/codex-ui/src/vue/components/context-menu/ContextMenu.vue
+++ b/codex-ui/src/vue/components/context-menu/ContextMenu.vue
@@ -18,16 +18,11 @@
       :class="$style['context-menu__scrollable']"
       :style="fixWidth !== 0 ? { width: fixWidth } : {}"
     >
-      <template v-if="filteredItems.length > 0">
-        <ContextMenuItem
-          v-for="(item, index) in filteredItems"
-          :key="index"
-          :item="item"
-        />
-      </template>
-      <template v-else>
-        <ContextMenuItem :item="messageItem" />
-      </template>
+      <ContextMenuItem
+        v-for="(item, index) in filteredItems"
+        :key="index"
+        :item="item"
+      />
     </div>
   </div>
 </template>
@@ -98,27 +93,24 @@ const filteredItems = computed(() => {
     }
   });
 
-  return removeSeparators(searchedItems);
-});
+  /**
+   * Deleting useless separators
+   */
+  if (searchedItems.length > 0) {
+    let items = searchedItems;
 
-/**
- * Deletes separators if they are at the beginning or end of the returned array
- *
- * @param items - filtered items array
- * @returns { Item[] } - array without unnecessary separators
- */
-function removeSeparators(items: Item[]): Item[] {
-  if (items.length > 0) {
-    if (items[0].type === 'separator') {
-      items = items.slice(1);
+    if (searchedItems[0].type === 'separator') {
+      items = searchedItems.slice(1);
     }
-    if (items[items.length - 1].type === 'separator') {
-      items = items.slice(0, items.length - 1);
+    if (searchedItems[searchedItems.length - 1].type === 'separator') {
+      items = searchedItems.slice(0, searchedItems.length - 1);
     }
+
+    return items;
+  } else {
+    return messageItem;
   }
-
-  return items;
-}
+});
 
 /**
  * Message for displaying in context menu if result of search is empty

--- a/codex-ui/src/vue/components/context-menu/ContextMenu.vue
+++ b/codex-ui/src/vue/components/context-menu/ContextMenu.vue
@@ -86,6 +86,9 @@ const filteredItems = computed(() => {
     return props.items;
   }
 
+  /**
+   * If the string entered by the user is included in some element, it will be returned
+   */
   const searchedItems = props.items.filter((item) => {
     if (item.type === 'message') {
       return false;
@@ -97,6 +100,9 @@ const filteredItems = computed(() => {
     }
   });
 
+  /**
+   * Deletes separators if they are at the beginning or end of the returned array
+   */
   if (searchedItems.length > 0) {
     return searchedItems[0].type === 'separator'
       ? searchedItems.slice(1)

--- a/codex-ui/src/vue/components/context-menu/ContextMenu.vue
+++ b/codex-ui/src/vue/components/context-menu/ContextMenu.vue
@@ -71,46 +71,62 @@ const searchTerm = ref('');
 /**
  * Returns the list of menu context items found during the search
  */
-const filteredItems = computed(() => {
+ const filteredItems = computed(() => {
+  const { items } = props;
+  const lowerCaseSearchTerm = searchTerm.value.toLowerCase();
+
   /**
    * If the user has not entered anything, the filter is not applied
    */
-  if (searchTerm.value === '') {
-    return props.items;
+  if (lowerCaseSearchTerm === '') {
+    return items;
   }
 
   /**
-   * If the string entered by the user is included in some element, it will be returned
+   * Check what item is separator
    */
-  const searchedItems = props.items.filter((item) => {
+  const isSeparator = (item: Item) => item.type === 'separator';
+
+  /**
+   * Checks if the element header contains the searched string
+   */
+  const includesSearchTerm = (item: Item) =>
+    (item.type === 'default' || !item.type) &&
+    item.title.toLowerCase().includes(lowerCaseSearchTerm);
+
+  /**
+   * Filtering items by search query
+   */
+  const searchedItems = items.filter((item) => {
     if (item.type === 'message') {
       return false;
-    } else if (item.type === 'separator') {
+    } else if (isSeparator(item)) {
       return true;
     } else {
-      return item.title.toLowerCase().includes(
-        searchTerm.value.toLowerCase());
+      return includesSearchTerm(item);
     }
   });
 
-  if (searchedItems.length > 0) {
-    if(searchedItems[0].type == 'separator') {
-      searchedItems.shift();
-    }
+  /**
+   * While the first element of the filtered array is a separator, remove it
+   */
+  while (searchedItems.length > 0 && isSeparator(searchedItems[0])) {
+    searchedItems.shift();
+  }
 
-    if(searchedItems.length == 0) {
-      searchedItems.push(messageItem)
-      return searchedItems;
-    }
+  /**
+   * While the last element of the filtered array is a separator, remove it
+   */
+  while (searchedItems.length > 0 && isSeparator(searchedItems[searchedItems.length - 1])) {
+    searchedItems.pop();
+  }
 
-    if(searchedItems[searchedItems.length - 1].type == 'separator') {
-      searchedItems.pop();
-    }
-
-    if(searchedItems.length == 0) {
-      searchedItems.push(messageItem)
-      return searchedItems;
-    }
+  /**
+   * If there are no elements in the filtered array, then nothing was found
+   * Returns the appropriate message
+   */
+  if (searchedItems.length === 0) {
+    searchedItems.push(messageItem);
   }
 
   return searchedItems;

--- a/codex-ui/src/vue/components/context-menu/ContextMenu.vue
+++ b/codex-ui/src/vue/components/context-menu/ContextMenu.vue
@@ -62,6 +62,9 @@ const props = withDefaults(
  */
 const searchTerm = ref('');
 
+/**
+ * Returns the list of menu context items found during the search
+ */
 const filteredItems = computed(() => {
   if (searchTerm.value === '') {
     return props.items;

--- a/codex-ui/src/vue/components/context-menu/ContextMenu.vue
+++ b/codex-ui/src/vue/components/context-menu/ContextMenu.vue
@@ -86,15 +86,17 @@ const filteredItems = computed(() => {
    * Check what item is separator
    *
    * @param item - item of items array
+   * @returns {boolean} true if item is separator, false otherwise
    */
-  const isSeparator = (item: Item) => item.type === 'separator';
+  const isSeparator = (item: Item): boolean => item.type === 'separator';
 
   /**
    * Checks if the element header contains the searched string
    *
-   * @param item- item of items array
+   * @param item - item of items array
+   * @returns {boolean} true if header contains the searched string
    */
-  const includesSearchTerm = (item: Item) =>
+  const includesSearchTerm = (item: Item): boolean =>
     (item.type === 'default' || !item.type)
     && item.title.toLowerCase().includes(lowerCaseSearchTerm);
 

--- a/codex-ui/src/vue/components/context-menu/ContextMenu.vue
+++ b/codex-ui/src/vue/components/context-menu/ContextMenu.vue
@@ -54,11 +54,6 @@ const props = withDefaults(
      * Array of items for context menu
      */
     items: Item[];
-
-    /**
-     * Message what occurs as a result of the search
-     */
-    message: string;
   }>(),
   { showSearch: false }
 );
@@ -117,7 +112,7 @@ const filteredItems = computed(() => {
  */
 const messageItem: Item = {
   type: 'message',
-  message: props.message,
+  message: 'Nothing found',
 };
 
 </script>

--- a/codex-ui/src/vue/components/context-menu/ContextMenu.vue
+++ b/codex-ui/src/vue/components/context-menu/ContextMenu.vue
@@ -77,6 +77,9 @@ const searchTerm = ref('');
  * Returns the list of menu context items found during the search
  */
 const filteredItems = computed(() => {
+  /**
+   * If the user has not entered anything, the filter is not applied
+   */
   if (searchTerm.value === '') {
     return props.items;
   }
@@ -95,17 +98,27 @@ const filteredItems = computed(() => {
     }
   });
 
-  /**
-   * Deletes separators if they are at the beginning or end of the returned array
-   */
-  if (searchedItems.length > 0) {
-    return searchedItems[0].type === 'separator'
-      ? searchedItems.slice(1)
-      : searchedItems;
+  return removeSeparators(searchedItems);
+});
+
+/**
+ * Deletes separators if they are at the beginning or end of the returned array
+ *
+ * @param items - filtered items array
+ * @returns { Item[] } - array without unnecessary separators
+ */
+function removeSeparators(items: Item[]): Item[] {
+  if (items.length > 0) {
+    if (items[0].type === 'separator') {
+      items = items.slice(1);
+    }
+    if (items[items.length - 1].type === 'separator') {
+      items = items.slice(0, items.length - 1);
+    }
   }
 
-  return searchedItems;
-});
+  return items;
+}
 
 /**
  * Message for displaying in context menu if result of search is empty

--- a/codex-ui/src/vue/components/context-menu/ContextMenu.vue
+++ b/codex-ui/src/vue/components/context-menu/ContextMenu.vue
@@ -93,23 +93,27 @@ const filteredItems = computed(() => {
     }
   });
 
-  /**
-   * Deleting useless separators
-   */
   if (searchedItems.length > 0) {
-    let items = searchedItems;
-
-    if (searchedItems[0].type === 'separator') {
-      items = searchedItems.slice(1);
-    }
-    if (searchedItems[searchedItems.length - 1].type === 'separator') {
-      items = searchedItems.slice(0, searchedItems.length - 1);
+    if(searchedItems[0].type == 'separator') {
+      searchedItems.shift();
     }
 
-    return items;
-  } else {
-    return messageItem;
+    if(searchedItems.length == 0) {
+      searchedItems.push(messageItem)
+      return searchedItems;
+    }
+
+    if(searchedItems[searchedItems.length - 1].type == 'separator') {
+      searchedItems.pop();
+    }
+
+    if(searchedItems.length == 0) {
+      searchedItems.push(messageItem)
+      return searchedItems;
+    }
   }
+
+  return searchedItems;
 });
 
 /**

--- a/codex-ui/src/vue/components/context-menu/ContextMenu.vue
+++ b/codex-ui/src/vue/components/context-menu/ContextMenu.vue
@@ -71,7 +71,7 @@ const searchTerm = ref('');
 /**
  * Returns the list of menu context items found during the search
  */
- const filteredItems = computed(() => {
+const filteredItems = computed(() => {
   const { items } = props;
   const lowerCaseSearchTerm = searchTerm.value.toLowerCase();
 
@@ -84,15 +84,19 @@ const searchTerm = ref('');
 
   /**
    * Check what item is separator
+   *
+   * @param item - item of items array
    */
   const isSeparator = (item: Item) => item.type === 'separator';
 
   /**
    * Checks if the element header contains the searched string
+   *
+   * @param item- item of items array
    */
   const includesSearchTerm = (item: Item) =>
-    (item.type === 'default' || !item.type) &&
-    item.title.toLowerCase().includes(lowerCaseSearchTerm);
+    (item.type === 'default' || !item.type)
+    && item.title.toLowerCase().includes(lowerCaseSearchTerm);
 
   /**
    * Filtering items by search query

--- a/codex-ui/src/vue/components/context-menu/ContextMenu.vue
+++ b/codex-ui/src/vue/components/context-menu/ContextMenu.vue
@@ -1,5 +1,8 @@
 <template>
-  <div :class="$style['context-menu']">
+  <div
+    ref="contextMenu"
+    :class="$style['context-menu']"
+  >
     <div
       v-if="showSearch"
       :class="$style['context-menu__search']"
@@ -11,7 +14,10 @@
       />
       <ContextMenuItem :item="separator" />
     </div>
-    <div :class="$style['context-menu__scrollable']">
+    <div
+      :class="$style['context-menu__scrollable']"
+      :style="fixWidth !== 0 ? { width: fixWidth } : {}"
+    >
       <template v-if="filteredItems.length > 0">
         <ContextMenuItem
           v-for="(item, index) in filteredItems"
@@ -27,7 +33,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import Input from '../input/Input.vue';
 import type { ContextMenuItem as Item } from './ContextMenu.types';
 import ContextMenuItem from './ContextMenuItem.vue';
@@ -56,6 +62,16 @@ const props = withDefaults(
   }>(),
   { showSearch: false }
 );
+
+const contextMenu = ref();
+let fixWidth = 0;
+
+/**
+ * Calculates the fixed width of the container after mounting
+ */
+onMounted(() => {
+  fixWidth = contextMenu.value.getBoundingClientRect().width;
+});
 
 /**
  * User entered word for search

--- a/codex-ui/src/vue/components/context-menu/ContextMenu.vue
+++ b/codex-ui/src/vue/components/context-menu/ContextMenu.vue
@@ -67,14 +67,24 @@ const filteredItems = computed(() => {
     return props.items;
   }
 
-  return props.items.filter((item) => {
-    if (item.type === 'separator' || item.type === 'message') {
+  const searchedItems = props.items.filter((item) => {
+    if (item.type === 'message') {
       return false;
+    } else if (item.type === 'separator') {
+      return true;
     } else {
       return item.title.toLowerCase().includes(
         searchTerm.value.toLowerCase());
     }
   });
+
+  if (searchedItems.length > 0) {
+    return searchedItems[0].type === 'separator'
+      ? searchedItems.slice(1)
+      : searchedItems;
+  }
+
+  return searchedItems;
 });
 
 /**

--- a/codex-ui/src/vue/components/context-menu/ContextMenuItem.vue
+++ b/codex-ui/src/vue/components/context-menu/ContextMenuItem.vue
@@ -23,6 +23,13 @@
     >
       <div :class="$style['item__line']" />
     </div>
+    <div
+      v-if="item.type === 'message'"
+      :class="[$style['item__default'],
+               $style['item__default--no-hover']]"
+    >
+      {{ item.message }}
+    </div>
   </div>
 </template>
 
@@ -54,9 +61,13 @@ defineProps<{
     gap: var(--v-padding);
     border-radius: var(--radius-m);
     padding: var(--v-padding) var(--h-padding);
+
+    &--no-hover {
+      cursor: default;
+    }
   }
 
-  &__default:hover {
+  .item__default:not(.item__default--no-hover):hover {
     background-color: var(--base--bg-secondary-hover);
     cursor: pointer;
   }


### PR DESCRIPTION
Now it is possible to search for an item among menu context items.
The items of show-case array has been modified to test the `context menu`.

![image](https://github.com/codex-team/notes.web/assets/94054053/9285551b-a249-45a9-a09a-baab95fc61cb)

Added a filtering feature that allows you to search among the `menu context` items. If the entered string is a substring of an item, it appears in the menu context. Separators remain between elements, but are removed from the beginning and end of the derived array.

![image](https://github.com/codex-team/notes.web/assets/94054053/5d0ba12c-a24b-4239-b66b-ad6f2f222c7f)

If no item is found, the menu context displays the corresponding message.

![image](https://github.com/codex-team/notes.web/assets/94054053/8cabe952-5b19-4ca1-b29f-f1287fcf0c75)