### PR TITLE
chore(design): Fixed root text styles for app

### DIFF
--- a/codex-ui/src/vue/components/card/Card.vue
+++ b/codex-ui/src/vue/components/card/Card.vue
@@ -89,6 +89,10 @@ withDefaults(
     }
   }
 
+  &__subtitle {
+    color: var(--base--text-secondary);
+  }
+
   &--vertical {
     width: var(--card-width);
   }

--- a/src/App.vue
+++ b/src/App.vue
@@ -35,7 +35,7 @@ body {
 #app {
   min-height: 100%;
   background: var(--base--bg-primary);
-  color: var(--base--text-secondary);
+  color: var(--base--text);
   word-break: break-word;
   font-family: 'Source Sans Pro', sans-serif;
   -webkit-font-smoothing: antialiased;

--- a/src/presentation/pages/Settings.vue
+++ b/src/presentation/pages/Settings.vue
@@ -112,7 +112,6 @@ async function uninstallClicked(toolId: string) {
 .page-header {
   padding: 0 var(--h-padding);
   gap: var(--spacing-s);
-  color: var(--base--text);
 
   h1 {
     font-size: 42px;


### PR DESCRIPTION
Now default text color would be var(--base--text) white, as it is in codex-ui package
it was (--base--text-secondary) light grey