### PR TITLE
feat(note-settings)/parent-note-card

### DIFF
--- a/src/application/i18n/messages/en.json
+++ b/src/application/i18n/messages/en.json
@@ -50,7 +50,7 @@
   },
   "note": {
     "new": "New Note",
-    "unlink": "Unlink from parent",
+    "unlink": "Unlink parent",
     "untitled": "Untitled",
     "open": "Open",
     "createChildNote": "Create child note"

--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -289,7 +289,6 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
       if (error instanceof Error) {
         window.alert(error.message);
       }
-      throw error;
     }
   };
 

--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -71,13 +71,6 @@ interface UseNoteComposableState {
   unlinkParent: () => Promise<void>;
 
   /**
-   * Set parent for the note
-   * @param id - Child note id
-   * @param newParentURL - New parent note URL
-   */
-  setParent: (id: NoteId, newParentURL: string) => Promise<void>;
-
-  /**
    * Defines if user can edit note
    */
   canEdit: Ref<boolean>;
@@ -278,21 +271,6 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
   }
 
   /**
-   * Set parent for the note
-   * @param id - Child note id
-   * @param newParentURL - New parent note URL
-   */
-  const setParent = async (id: NoteId, newParentURL: string): Promise<void> => {
-    try {
-      parentNote.value = await noteService.setParentByUrl(id, newParentURL);
-    } catch (error) {
-      if (error instanceof Error) {
-        window.alert(error.message);
-      }
-    }
-  };
-
-  /**
    * Get note by custom hostname
    */
   const resolveHostname = async (): Promise<void> => {
@@ -349,7 +327,6 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
     resolveToolsByContent,
     save,
     unlinkParent,
-    setParent,
     parentNote,
   };
 }

--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -71,6 +71,13 @@ interface UseNoteComposableState {
   unlinkParent: () => Promise<void>;
 
   /**
+   * Set parent for the note
+   * @param id - Child note id
+   * @param newParentURL - New parent note URL
+   */
+  setParent: (id: NoteId, newParentURL: string) => Promise<void>;
+
+  /**
    * Defines if user can edit note
    */
   canEdit: Ref<boolean>;
@@ -271,6 +278,22 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
   }
 
   /**
+   * Set parent for the note
+   * @param id - Child note id
+   * @param newParentURL - New parent note URL
+   */
+  const setParent = async (id: NoteId, newParentURL: string): Promise<void> => {
+    try {
+      parentNote.value = await noteService.setParentByUrl(id, newParentURL);
+    } catch (error) {
+      if (error instanceof Error) {
+        window.alert(error.message);
+      }
+      throw error;
+    }
+  };
+
+  /**
    * Get note by custom hostname
    */
   const resolveHostname = async (): Promise<void> => {
@@ -327,6 +350,7 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
     resolveToolsByContent,
     save,
     unlinkParent,
+    setParent,
     parentNote,
   };
 }

--- a/src/application/services/useNoteSettings.ts
+++ b/src/application/services/useNoteSettings.ts
@@ -1,7 +1,7 @@
 import { ref, type Ref } from 'vue';
 import type NoteSettings from '@/domain/entities/NoteSettings';
-import type { NoteId, Note } from '@/domain/entities/Note';
-import { noteSettingsService, noteService } from '@/domain';
+import type { NoteId } from '@/domain/entities/Note';
+import { noteSettingsService } from '@/domain';
 import type { UserId } from '@/domain/entities/User';
 import type { MemberRole } from '@/domain/entities/Team';
 import { useRouter } from 'vue-router';
@@ -14,11 +14,6 @@ interface UseNoteSettingsComposableState {
    * NoteSettings ref
    */
   noteSettings: Ref<NoteSettings | null>;
-
-  /**
-   * Instance of the parent note, undefined if there is no parent note
-   */
-  parentNote: Ref<Note | undefined>;
 
   /**
    * Load note settings
@@ -59,13 +54,6 @@ interface UseNoteSettingsComposableState {
    * @param data - picture binary data
    */
   updateCover: (id: NoteId, data: Blob) => Promise<void>;
-
-  /**
-   * Set parent for the note
-   * @param id - Child note id
-   * @param newParentURL - New parent note URL
-   */
-  setParent: (id: NoteId, newParentURL: string) => Promise<void>;
 }
 
 /**
@@ -78,11 +66,6 @@ export default function (): UseNoteSettingsComposableState {
   const noteSettings = ref<NoteSettings | null>(null);
 
   /**
-   * Instance of the parent note, undefined if there is no parent note
-   */
-  const parentNote = ref<Note | undefined>();
-
-  /**
    * Router instance used to replace the current route with note id
    */
   const router = useRouter();
@@ -93,9 +76,6 @@ export default function (): UseNoteSettingsComposableState {
    */
   const load = async (id: NoteId): Promise<void> => {
     noteSettings.value = await noteSettingsService.getNoteSettingsById(id);
-    const response = await noteService.getNoteById(id);
-
-    parentNote.value = response.parentNote;
   };
 
   /**
@@ -169,31 +149,13 @@ export default function (): UseNoteSettingsComposableState {
     }
   };
 
-  /**
-   * Set parent for the note
-   * @param id - Child note id
-   * @param newParentURL - New parent note URL
-   */
-  const setParent = async (id: NoteId, newParentURL: string): Promise<void> => {
-    try {
-      parentNote.value = await noteService.setParentByUrl(id, newParentURL);
-    } catch (error) {
-      if (error instanceof Error) {
-        window.alert(error.message);
-      }
-      throw error;
-    }
-  };
-
   return {
     updateCover,
-    parentNote,
     noteSettings,
     load,
     updateIsPublic,
     revokeHash,
     changeRole,
     deleteNoteById,
-    setParent,
   };
 }

--- a/src/application/services/useNoteSettings.ts
+++ b/src/application/services/useNoteSettings.ts
@@ -160,7 +160,7 @@ export default function (): UseNoteSettingsComposableState {
    * @param id - Child note id
    * @param newParentURL - New parent note URL
    */
-  const setParent = async (id: NoteId, newParentURL: string): Promise<void> => {
+  async function setParent(id: NoteId, newParentURL: string): Promise<void> {
     try {
       parentNote.value = await noteService.setParentByUrl(id, newParentURL);
     } catch (error) {

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -52,7 +52,7 @@ const props = defineProps<{
 
 const noteId = toRef(props, 'id');
 
-const { note, noteTools, save, noteTitle, canEdit, unlinkParent, parentNote } = useNote({
+const { note, noteTools, save, noteTitle, canEdit } = useNote({
   id: noteId,
 });
 
@@ -116,17 +116,6 @@ function createChildNote(): void {
     throw new Error('Note is Empty');
   }
   router.push(`/note/${props.id}/new`);
-}
-
-/**
- * Unlink note from parent
- */
-function unlinkButton(): void {
-  if (props.id === null) {
-    throw new Error('Note is Empty');
-  }
-
-  unlinkParent();
 }
 
 watch(

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -10,13 +10,6 @@
       >
         {{ t('note.createChildNote') }}
       </Button>
-
-      <Button
-        v-if="parentNote != undefined"
-        @click="unlinkButton"
-      >
-        {{ t('note.unlink') }}
-      </Button>
     </div>
     <Editor
       v-if="isToolsLoaded"

--- a/src/presentation/pages/NoteSettings.vue
+++ b/src/presentation/pages/NoteSettings.vue
@@ -36,7 +36,7 @@
         <div class="button">
           <Button
             secondary
-            @click="unlinkParent"
+            @click="handleUnlinkParentClick"
           >
             {{ t('note.unlink') }}
           </Button>
@@ -143,6 +143,14 @@ async function deleteNote() {
   if (isConfirmed) {
     deleteNoteById(props.id);
   }
+}
+
+/**
+ * Unlink parent note and clear the parentURL field
+ */
+async function handleUnlinkParentClick() {
+  parentURL.value = '';
+  unlinkParent();
 }
 
 /**

--- a/src/presentation/pages/NoteSettings.vue
+++ b/src/presentation/pages/NoteSettings.vue
@@ -24,29 +24,30 @@
         :caption="t('noteSettings.parentNoteCaption')"
         :with-background="false"
       >
-        <Field
-          v-model="parentURL"
-
-          :disabled="parentNote !== undefined"
-          :placeholder="t('noteSettings.parentNotePlaceholder')"
-          @input="setParentDebounced"
-        />
-
-        <Card
-          v-if="parentNote"
-          :title="parentNoteTitle"
-          :subtitle="parentNote.updatedAt"
-          orientation="horizontal"
-        >
-          <div class="button">
-            <Button
-              secondary
-              @click="handleUnlinkParentClick"
-            >
-              {{ t('note.unlink') }}
-            </Button>
-          </div>
-        </Card>
+        <div class="change-parent">
+          <Input
+            v-model="parentURL"
+            data-dimensions="large"
+            :disabled="parentNote !== undefined"
+            :placeholder="t('noteSettings.parentNotePlaceholder')"
+            @input="setParentDebounced"
+          />
+          <Card
+            v-if="parentNote"
+            :title="parentNoteTitle"
+            :subtitle="formatShortDate(parentNote.createdAt!)"
+            orientation="horizontal"
+          >
+            <div class="change-parent__button">
+              <Button
+                secondary
+                @click="handleUnlinkParentClick"
+              >
+                {{ t('note.unlink') }}
+              </Button>
+            </div>
+          </Card>
+        </div>
       </Section>
 
       <Section
@@ -100,7 +101,6 @@
 
 <script lang="ts" setup>
 import type { NoteId } from '@/domain/entities/Note';
-// import TextEdit from '@/presentation/components/form/TextEdit.vue';
 import useNoteSettings from '@/application/services/useNoteSettings';
 import useNote from '@/application/services/useNote';
 import { useHead } from 'unhead';
@@ -108,8 +108,9 @@ import { useI18n } from 'vue-i18n';
 import { computed, ref, onMounted } from 'vue';
 import { useDebounceFn } from '@vueuse/core';
 import Team from '@/presentation/components/team/Team.vue';
-import { Section, Row, Switch, Button, Field, Heading, Card } from 'codex-ui/vue';
+import { Section, Row, Switch, Button, Heading, Card, Input } from 'codex-ui/vue';
 import { getTitle } from '@/infrastructure/utils/note';
+import { formatShortDate } from '@/infrastructure/utils/date';
 
 const { t } = useI18n();
 
@@ -250,8 +251,15 @@ onMounted(async () => {
   margin: var(--spacing-xxl) 0;
 }
 
-.button {
-  justify-content: flex-end; /* Выравнивание содержимого по правому краю */
-  flex-grow: 1; /* Занимает всё доступное пространство */
+.change-parent{
+  display: flex;
+  flex-direction: column;
+  gap: var(--v-padding);
+
+  &__button{
+    display: flex;
+    justify-content: flex-end;
+    flex-grow: 1;
+  }
 }
 </style>

--- a/src/presentation/pages/NoteSettings.vue
+++ b/src/presentation/pages/NoteSettings.vue
@@ -27,6 +27,21 @@
         :placeholder="t('noteSettings.parentNotePlaceholder')"
         @input="setParentDebounced"
       />
+      <Card
+        v-if="parentNote"
+        :title="parentNoteTitle"
+        :subtitle="parentNote.updatedAt"
+        orientation="horizontal"
+      >
+        <div class="button">
+          <Button
+            secondary
+            @click="unlinkParent"
+          >
+            {{ t('note.unlink') }}
+          </Button>
+        </div>
+      </Card>
       <Section
         :title="t('noteSettings.availabilityTitle')"
         :caption="t('noteSettings.availabilityCaption')"
@@ -86,7 +101,8 @@ import { useI18n } from 'vue-i18n';
 import { computed, ref, onMounted } from 'vue';
 import { useDebounceFn } from '@vueuse/core';
 import Team from '@/presentation/components/team/Team.vue';
-import { Section, Row, Switch, Button, Field, Heading } from 'codex-ui/vue';
+import { Section, Row, Switch, Button, Field, Heading, Card } from 'codex-ui/vue';
+import { getTitle } from '@/infrastructure/utils/note';
 
 const { t } = useI18n();
 
@@ -97,8 +113,8 @@ const props = defineProps<{
   id: NoteId;
 }>();
 
-const { noteSettings, parentNote, load: loadSettings, updateIsPublic, revokeHash, deleteNoteById, setParent } = useNoteSettings();
-const { noteTitle } = useNote({
+const { noteSettings, load: loadSettings, updateIsPublic, revokeHash, deleteNoteById } = useNoteSettings();
+const { noteTitle, parentNote, setParent, unlinkParent } = useNote({
   id: props.id,
 });
 
@@ -137,6 +153,14 @@ const setParentDebounced = useDebounceFn(async () => {
     await setParent(props.id, parentURL.value);
   }
 }, 1000);
+
+const parentNoteTitle = computed(() => {
+  if (parentNote.value === undefined) {
+    return '';
+  }
+
+  return getTitle(parentNote.value.content);
+});
 
 /**
  * Current value of isPublic field
@@ -209,5 +233,10 @@ onMounted(async () => {
   flex-direction: column;
   gap: var(--spacing-xxl);
   margin: var(--spacing-xxl) 0;
+}
+
+.button {
+  justify-content: flex-end; /* Выравнивание содержимого по правому краю */
+  flex-grow: 1; /* Занимает всё доступное пространство */
 }
 </style>

--- a/src/presentation/pages/NoteSettings.vue
+++ b/src/presentation/pages/NoteSettings.vue
@@ -19,29 +19,36 @@
       </Heading>
     </div>
     <div class="form">
-      <Field
-        v-model="parentURL"
+      <Section
         :title="t('noteSettings.parentNote')"
         :caption="t('noteSettings.parentNoteCaption')"
-        :disabled="parentNote !== undefined"
-        :placeholder="t('noteSettings.parentNotePlaceholder')"
-        @input="setParentDebounced"
-      />
-      <Card
-        v-if="parentNote"
-        :title="parentNoteTitle"
-        :subtitle="parentNote.updatedAt"
-        orientation="horizontal"
+        :with-background="false"
       >
-        <div class="button">
-          <Button
-            secondary
-            @click="handleUnlinkParentClick"
-          >
-            {{ t('note.unlink') }}
-          </Button>
-        </div>
-      </Card>
+        <Field
+          v-model="parentURL"
+
+          :disabled="parentNote !== undefined"
+          :placeholder="t('noteSettings.parentNotePlaceholder')"
+          @input="setParentDebounced"
+        />
+
+        <Card
+          v-if="parentNote"
+          :title="parentNoteTitle"
+          :subtitle="parentNote.updatedAt"
+          orientation="horizontal"
+        >
+          <div class="button">
+            <Button
+              secondary
+              @click="handleUnlinkParentClick"
+            >
+              {{ t('note.unlink') }}
+            </Button>
+          </div>
+        </Card>
+      </Section>
+
       <Section
         :title="t('noteSettings.availabilityTitle')"
         :caption="t('noteSettings.availabilityCaption')"

--- a/src/presentation/pages/NoteSettings.vue
+++ b/src/presentation/pages/NoteSettings.vue
@@ -119,8 +119,8 @@ const props = defineProps<{
   id: NoteId;
 }>();
 
-const { noteSettings, load: loadSettings, updateIsPublic, revokeHash, deleteNoteById } = useNoteSettings();
-const { noteTitle, parentNote, setParent, unlinkParent } = useNote({
+const { noteSettings, load: loadSettings, updateIsPublic, revokeHash, deleteNoteById, parentNote, setParent } = useNoteSettings();
+const { noteTitle, unlinkParent } = useNote({
   id: props.id,
 });
 

--- a/src/presentation/pages/NoteSettings.vue
+++ b/src/presentation/pages/NoteSettings.vue
@@ -156,6 +156,7 @@ async function deleteNote() {
  */
 async function handleUnlinkParentClick() {
   parentURL.value = '';
+  parentNote.value = undefined;
   unlinkParent();
 }
 

--- a/src/presentation/pages/NoteSettings.vue
+++ b/src/presentation/pages/NoteSettings.vue
@@ -38,14 +38,12 @@
             :subtitle="formatShortDate(parentNote.createdAt!)"
             orientation="horizontal"
           >
-            <div class="change-parent__button">
-              <Button
-                secondary
-                @click="handleUnlinkParentClick"
-              >
-                {{ t('note.unlink') }}
-              </Button>
-            </div>
+            <Button
+              secondary
+              @click="handleUnlinkParentClick"
+            >
+              {{ t('note.unlink') }}
+            </Button>
           </Card>
         </div>
       </Section>
@@ -256,10 +254,5 @@ onMounted(async () => {
   flex-direction: column;
   gap: var(--v-padding);
 
-  &__button{
-    display: flex;
-    justify-content: flex-end;
-    flex-grow: 1;
-  }
 }
 </style>


### PR DESCRIPTION
From now we can see parent note card in note settings page.
Also unlink button was removed from note page. Now you can unlink note from not settings page. 
ParentNote and setParent were moved to useNote

**With parent note**
<img width="667" alt="Снимок экрана 2024-07-03 в 17 18 59" src="https://github.com/codex-team/notes.web/assets/112954605/1b01f91b-44ca-46e3-aacd-6dbe479545e9">

**Without parent note**
<img width="656" alt="Снимок экрана 2024-07-03 в 17 34 00" src="https://github.com/codex-team/notes.web/assets/112954605/ca7daff3-3ec8-4e26-b9fd-11da2b277d62">

