### PR TITLE
fix(editor): placeholders fixed

### DIFF
--- a/codex-ui/dev/pages/Index.vue
+++ b/codex-ui/dev/pages/Index.vue
@@ -19,7 +19,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100%;
+  height: 80vh;
 
   &__logo {
     font-size: 120px;

--- a/src/presentation/styles/reset.pcss
+++ b/src/presentation/styles/reset.pcss
@@ -139,35 +139,6 @@ svg {
   display: block;
 }
 
-input {
-  width: 100%;
-  height: 100%;
-  margin: 0;
-  padding: 0;
-  font: inherit;
-  line-height: 1;
-  color: inherit;
-  background-color: transparent;
-  border: none;
-  box-shadow: none;
-  outline: none;
-  appearance: none;
-
-  &[disabled]::placeholder {
-    color: inherit;
-  }
-
-  &:-webkit-autofill {
-    &,
-    &:hover,
-    &:focus,
-    &:active {
-      transition-delay: 9999s;
-      transition-property: background-color, color;
-    }
-  }
-}
-
 h1, h2, h3, h4, h5, h6 {
   margin: unset;
 }


### PR DESCRIPTION
## Problem

Placeholders in editor goes away in Safari

<img width="432" alt="image" src="https://github.com/user-attachments/assets/8afe0618-2589-458f-a20e-6727cfec2932">

<img width="558" alt="image" src="https://github.com/user-attachments/assets/5dd3a055-a2be-415d-9099-2a762dd95a61">

## Cause 

Our CSS `reset.pcss` sets input height to 100% 

## Solution

I've removed input styles reset

![image](https://github.com/user-attachments/assets/e70fe10e-c540-4146-8cd3-6d38dc137082)
