### PR TITLE
chore(settings): fixed jumping theme changer

### DIFF
--- a/codex-ui/src/vue/components/row/Row.vue
+++ b/codex-ui/src/vue/components/row/Row.vue
@@ -102,6 +102,7 @@ defineProps<{
   }
 
   &__center {
+    height: 20px;
     flex: 1;
     display: flex;
     flex-direction: column;

--- a/codex-ui/src/vue/components/row/Row.vue
+++ b/codex-ui/src/vue/components/row/Row.vue
@@ -102,7 +102,6 @@ defineProps<{
   }
 
   &__center {
-    min-height: 20px;
     flex: 1;
     display: flex;
     flex-direction: column;

--- a/codex-ui/src/vue/components/row/Row.vue
+++ b/codex-ui/src/vue/components/row/Row.vue
@@ -102,7 +102,7 @@ defineProps<{
   }
 
   &__center {
-    height: 20px;
+    min-height: 20px;
     flex: 1;
     display: flex;
     flex-direction: column;

--- a/src/presentation/pages/Settings.vue
+++ b/src/presentation/pages/Settings.vue
@@ -230,7 +230,7 @@ async function uninstallClicked(toolId: string) {
 }
 </script>
 
-<style scoped lang="postcss" module>
+<style lang="postcss" module>
 .container {
   display: grid;
   padding: var(--spacing-xxl) 0;
@@ -256,6 +256,10 @@ async function uninstallClicked(toolId: string) {
 
     &-theme-row {
       cursor: pointer;
+
+      :global(.codex-row__center) {
+        min-height: 20px;
+      }
 
       &:first-of-type {
         border-top-left-radius: var(--radius-field);

--- a/src/presentation/pages/Settings.vue
+++ b/src/presentation/pages/Settings.vue
@@ -58,10 +58,12 @@
                 <DarkColorShemeIcon v-if="scheme === 'Dark'" />
               </template>
               <template
-                v-if="colorScheme === scheme.toLowerCase()"
                 #right
               >
-                <Icon name="Check" />
+                <Icon
+                  name="Check"
+                  :style="colorScheme === scheme.toLowerCase() ? 'opacity: 1;' : 'opacity: 0;'"
+                />
               </template>
             </Row>
           </Section>
@@ -82,10 +84,12 @@
                 <ThemePreview :theme="theme" />
               </template>
               <template
-                v-if="themeBase === theme.toLowerCase()"
                 #right
               >
-                <Icon name="Check" />
+                <Icon
+                  name="Check"
+                  :style="themeBase === theme.toLowerCase() ? 'opacity: 1;' : 'opacity: 0;'"
+                />
               </template>
             </Row>
           </Section>
@@ -106,10 +110,12 @@
                 <ThemePreview :theme="theme" />
               </template>
               <template
-                v-if="themeAccent === theme.toLowerCase()"
                 #right
               >
-                <Icon name="Check" />
+                <Icon
+                  name="Check"
+                  :style="themeAccent === theme.toLowerCase() ? 'opacity: 1;' : 'opacity: 0;'"
+                />
               </template>
             </Row>
           </Section>

--- a/src/presentation/pages/Settings.vue
+++ b/src/presentation/pages/Settings.vue
@@ -58,12 +58,10 @@
                 <DarkColorShemeIcon v-if="scheme === 'Dark'" />
               </template>
               <template
+                v-if="colorScheme === scheme.toLowerCase()"
                 #right
               >
-                <Icon
-                  name="Check"
-                  :style="colorScheme === scheme.toLowerCase() ? 'opacity: 1;' : 'opacity: 0;'"
-                />
+                <Icon name="Check" />
               </template>
             </Row>
           </Section>
@@ -84,12 +82,10 @@
                 <ThemePreview :theme="theme" />
               </template>
               <template
+                v-if="themeBase === theme.toLowerCase()"
                 #right
               >
-                <Icon
-                  name="Check"
-                  :style="themeBase === theme.toLowerCase() ? 'opacity: 1;' : 'opacity: 0;'"
-                />
+                <Icon name="Check" />
               </template>
             </Row>
           </Section>
@@ -110,12 +106,10 @@
                 <ThemePreview :theme="theme" />
               </template>
               <template
+                v-if="themeAccent === theme.toLowerCase()"
                 #right
               >
-                <Icon
-                  name="Check"
-                  :style="themeAccent === theme.toLowerCase() ? 'opacity: 1;' : 'opacity: 0;'"
-                />
+                <Icon name="Check" />
               </template>
             </Row>
           </Section>


### PR DESCRIPTION
## Problem 
Since row height is not fixed, it depends on content,
when we add icon `check` row's height becomes larger for some screens (`text-ui-base-medium` font-size set in rem, so for some screens font-size would be less or than 20px, so when icon added height of one certain row would be changed)

## Solution
Now icon `check` is always displayed, but with opacity 0, for current theme with opacity 1
- with icon `check`
![image](https://github.com/user-attachments/assets/61199774-b43d-44fe-ae96-37bd52fa1ddb)
- without icon `check`
![image](https://github.com/user-attachments/assets/0bff35e3-fd5d-46ec-91ce-f619eb83e081)
