### PR TITLE
feat(note-history): added note-history page

### DIFF
--- a/src/application/i18n/messages/en.json
+++ b/src/application/i18n/messages/en.json
@@ -81,6 +81,10 @@
     },
     "lastEdit": "Last edit"
   },
+  "history": {
+    "title": "Versions history",
+    "view": "View"
+  },
   "noteList": {
     "emptyNoteList": "No Notes yet. Make your first note",
     "noteListItem": {
@@ -170,6 +174,7 @@
     "addTool": "Add tool",
     "notFound": "Not found",
     "joinTeam": "Join",
-    "authorization": "Authorize"
+    "authorization": "Authorize",
+    "history": "History"
   }
 }

--- a/src/application/router/routes.ts
+++ b/src/application/router/routes.ts
@@ -9,6 +9,7 @@ import AuthorizationPage from '@/presentation/pages/AuthorizationPage.vue';
 import type { RouteRecordRaw } from 'vue-router';
 import AddTool from '@/presentation/pages/marketplace/AddTool.vue';
 import MarketplacePage from '@/presentation/pages/marketplace/MarketplacePage.vue';
+import History from '@/presentation/pages/History.vue';
 import MarketplaceTools from '@/presentation/pages/marketplace/MarketplaceTools.vue';
 
 // Default production hostname for homepage. If different, then custom hostname used
@@ -41,6 +42,19 @@ const routes: RouteRecordRaw[] = [
     },
     props: route => ({
       id: String(route.params.id),
+    }),
+  },
+  {
+    name: 'history',
+    path: '/note/:noteId/history',
+    component: History,
+    meta: {
+      layout: 'fullpage',
+      pageTitleI18n: 'pages.history',
+      authRequired: true,
+    },
+    props: route => ({
+      noteId: String(route.params.noteId),
     }),
   },
   {

--- a/src/application/services/useNoteHistory.ts
+++ b/src/application/services/useNoteHistory.ts
@@ -1,0 +1,33 @@
+import type { MaybeRefOrGetter, Ref } from 'vue';
+import { computed, onMounted, ref, toValue } from 'vue';
+import type { NoteHistoryRecord, NoteHistoryMeta } from '@/domain/entities/History';
+import type { Note } from '@/domain/entities/Note';
+import { noteHistoryService } from '@/domain';
+
+interface UseNoteHistoryComposableState {
+  noteHistory: Ref<NoteHistoryMeta[] | null>;
+}
+
+interface UseNoteHistoryComposableOptions {
+  noteId: MaybeRefOrGetter<NoteHistoryRecord['noteId'] | null>;
+}
+
+export default function useNoteHistory(options: UseNoteHistoryComposableOptions): UseNoteHistoryComposableState {
+  const noteHistory = ref<NoteHistoryMeta[] | null>(null);
+
+  const currentNoteId = computed(() => toValue(options.noteId));
+
+  async function loadNoteHistory(noteId: Note['id']): Promise<void> {
+    noteHistory.value = await noteHistoryService.loadNoteHistory(noteId);
+  }
+
+  onMounted(() => {
+    if (currentNoteId.value !== null) {
+      void loadNoteHistory(currentNoteId.value);
+    }
+  });
+
+  return {
+    noteHistory: noteHistory,
+  };
+}

--- a/src/application/services/useNoteHistory.ts
+++ b/src/application/services/useNoteHistory.ts
@@ -5,10 +5,16 @@ import type { Note } from '@/domain/entities/Note';
 import { noteHistoryService } from '@/domain';
 
 interface UseNoteHistoryComposableState {
+  /**
+   * Note hisotry is array of the history meta used for history preview
+   */
   noteHistory: Ref<NoteHistoryMeta[] | null>;
 }
 
 interface UseNoteHistoryComposableOptions {
+  /**
+   * Id of the note
+   */
   noteId: MaybeRefOrGetter<NoteHistoryRecord['noteId'] | null>;
 }
 
@@ -21,6 +27,9 @@ export default function useNoteHistory(options: UseNoteHistoryComposableOptions)
     noteHistory.value = await noteHistoryService.loadNoteHistory(noteId);
   }
 
+  /**
+   * When page is mounted, we should load note history
+   */
   onMounted(() => {
     if (currentNoteId.value !== null) {
       void loadNoteHistory(currentNoteId.value);

--- a/src/domain/entities/History.ts
+++ b/src/domain/entities/History.ts
@@ -1,0 +1,59 @@
+import type EditorTool from './EditorTool';
+import type { Note } from './Note';
+import type { User } from './User';
+
+interface UserMeta {
+  /**
+   * Name of the user
+   */
+  name: User['name'];
+
+  /**
+   * Photo of the user
+   */
+  photo: User['photo'];
+};
+
+export interface NoteHistoryRecord {
+  /**
+   * Unique identified of note history record
+   */
+  id: number;
+
+  /**
+   * Id of the note whose content history is stored
+   */
+  noteId: Note['id'];
+
+  /**
+   * User that updated note content
+   */
+  userId: User['id'];
+
+  /**
+   * Timestamp of note update
+   */
+  createdAt: string;
+
+  /**
+   * Version of note content
+   */
+  content: Note['content'];
+
+  /**
+   * Note tools of current version of note content
+   */
+  tools: EditorTool[];
+}
+
+/**
+ * Meta data of the note history record
+ * Used for presentation of the note history record in web
+ */
+export type NoteHistoryMeta = Omit<NoteHistoryRecord, 'content' | 'noteId' | 'tools'> & {
+  /**
+   * Meta data of the user who did changes
+   * Used for note history metadata presentation
+   */
+  user: UserMeta;
+};

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -9,6 +9,7 @@ import NoteListService from './noteList.service';
 import EditorToolsService from '@/domain/editorTools.service';
 import WorkspaceService from './workspace.service';
 import TeamService from './team.service';
+import NoteHistoryService from './noteHistory.service';
 /**
  * Get API url from environment
  */
@@ -36,6 +37,7 @@ const authService = new AuthService(eventBus, repositories.auth);
 const userService = new UserService(eventBus, repositories.user);
 const marketplaceService = new MarketplaceService(repositories.marketplace);
 const teamService = new TeamService(repositories.team);
+const noteHistoryService = new NoteHistoryService(repositories.noteHistory);
 
 /**
  * App State — is a read-only combination of app Stores.
@@ -60,5 +62,6 @@ export {
   userService,
   marketplaceService,
   workspaceService,
-  teamService
+  teamService,
+  noteHistoryService
 };

--- a/src/domain/noteHistory.repository.interface.ts
+++ b/src/domain/noteHistory.repository.interface.ts
@@ -1,0 +1,10 @@
+import type { NoteHistoryMeta } from './entities/History';
+import type { Note } from './entities/Note';
+
+export default interface NoteHistoryRepositoryInterface {
+  /**
+   * Loads note history meta for note history preview
+   * @param noteId - id of the note
+   */
+  loadNoteHistory(noteId: Note['id']): Promise<NoteHistoryMeta[]>;
+}

--- a/src/domain/noteHistory.repository.interface.ts
+++ b/src/domain/noteHistory.repository.interface.ts
@@ -1,6 +1,9 @@
 import type { NoteHistoryMeta } from './entities/History';
 import type { Note } from './entities/Note';
 
+/**
+ * Interface of the note history repository
+ */
 export default interface NoteHistoryRepositoryInterface {
   /**
    * Loads note history meta for note history preview

--- a/src/domain/noteHistory.service.ts
+++ b/src/domain/noteHistory.service.ts
@@ -1,0 +1,15 @@
+import type { NoteHistoryMeta } from './entities/History';
+import type { Note } from './entities/Note';
+import type NoteHistoryRepository from './noteHistory.repository.interface';
+
+export default class NoteHistoryService {
+  private readonly noteHistoryRepository: NoteHistoryRepository;
+
+  constructor(historyRepository: NoteHistoryRepository) {
+    this.noteHistoryRepository = historyRepository;
+  }
+
+  public async loadNoteHistory(noteId: Note['id']): Promise<NoteHistoryMeta[]> {
+    return await this.noteHistoryRepository.loadNoteHistory(noteId);
+  }
+}

--- a/src/domain/noteHistory.service.ts
+++ b/src/domain/noteHistory.service.ts
@@ -2,13 +2,24 @@ import type { NoteHistoryMeta } from './entities/History';
 import type { Note } from './entities/Note';
 import type NoteHistoryRepository from './noteHistory.repository.interface';
 
+/**
+ * Note history service class, used for logic handling of the data,
+ * Also used for data delivery from repository to application service
+ */
 export default class NoteHistoryService {
+  /**
+   * Note history repository instance
+   */
   private readonly noteHistoryRepository: NoteHistoryRepository;
 
   constructor(historyRepository: NoteHistoryRepository) {
     this.noteHistoryRepository = historyRepository;
   }
 
+  /**
+   * Loads note history meta for note history preview
+   * @param noteId - id of the note
+   */
   public async loadNoteHistory(noteId: Note['id']): Promise<NoteHistoryMeta[]> {
     return await this.noteHistoryRepository.loadNoteHistory(noteId);
   }

--- a/src/infrastructure/index.ts
+++ b/src/infrastructure/index.ts
@@ -17,6 +17,7 @@ import EditorToolsRepository from '@/infrastructure/editorTools.repository';
 import EditorToolsTransport from '@/infrastructure/transport/editorTools.transport';
 import NoteAttachmentUploaderRepository from './noteAttachmentUploader.repository';
 import TeamRepository from '@/infrastructure/team.repository';
+import NoteHistoryRepository from './noteHistory.repository';
 
 /**
  * Repositories
@@ -66,6 +67,11 @@ export interface Repositories {
    * Working with teams
    */
   team: TeamRepository;
+
+  /**
+   * Working with note history
+   */
+  noteHistory: NoteHistoryRepository;
 }
 
 /**
@@ -135,6 +141,7 @@ export function init(noteApiUrl: string, eventBus: EventBus): Repositories {
   const noteAttachmentUploaderRepository = new NoteAttachmentUploaderRepository(notesApiTransport);
   const workspaceRepository = new WorkspaceRepository(openedPagesStore);
   const teamRepository = new TeamRepository(notesApiTransport);
+  const noteHistoryRepository = new NoteHistoryRepository(notesApiTransport);
 
   return {
     note: noteRepository,
@@ -146,5 +153,6 @@ export function init(noteApiUrl: string, eventBus: EventBus): Repositories {
     noteAttachmentUploader: noteAttachmentUploaderRepository,
     workspace: workspaceRepository,
     team: teamRepository,
+    noteHistory: noteHistoryRepository,
   };
 }

--- a/src/infrastructure/noteHistory.repository.ts
+++ b/src/infrastructure/noteHistory.repository.ts
@@ -1,0 +1,21 @@
+import type NoteHistoryRepositoryInterface from '@/domain/noteHistory.repository.interface';
+import type NotesApiTransport from './transport/notes-api';
+import type { Note } from '@/domain/entities/Note';
+import type { NoteHistoryMeta } from '@/domain/entities/History';
+
+export default class NoteHistoryRepository implements NoteHistoryRepositoryInterface {
+  private readonly transport: NotesApiTransport;
+
+  constructor(notesApiTransport: NotesApiTransport) {
+    this.transport = notesApiTransport;
+  }
+
+  public async loadNoteHistory(noteId: Note['id']): Promise<NoteHistoryMeta[]> {
+    console.log('noteIID', noteId);
+    const response = await this.transport.get<{ noteHistoryMeta: NoteHistoryMeta[] }>(`/note/${noteId}/history`);
+
+    console.log('resssssss', response);
+
+    return response.noteHistoryMeta;
+  }
+}

--- a/src/infrastructure/noteHistory.repository.ts
+++ b/src/infrastructure/noteHistory.repository.ts
@@ -3,18 +3,25 @@ import type NotesApiTransport from './transport/notes-api';
 import type { Note } from '@/domain/entities/Note';
 import type { NoteHistoryMeta } from '@/domain/entities/History';
 
+/**
+ * Note history repository class used for data delivery from transport to service
+ */
 export default class NoteHistoryRepository implements NoteHistoryRepositoryInterface {
+  /**
+   * Notes api transport instance
+   */
   private readonly transport: NotesApiTransport;
 
   constructor(notesApiTransport: NotesApiTransport) {
     this.transport = notesApiTransport;
   }
 
+  /**
+   * Loads note history meta for note history preview
+   * @param noteId - id of the note
+   */
   public async loadNoteHistory(noteId: Note['id']): Promise<NoteHistoryMeta[]> {
-    console.log('noteIID', noteId);
     const response = await this.transport.get<{ noteHistoryMeta: NoteHistoryMeta[] }>(`/note/${noteId}/history`);
-
-    console.log('resssssss', response);
 
     return response.noteHistoryMeta;
   }

--- a/src/infrastructure/utils/date.ts
+++ b/src/infrastructure/utils/date.ts
@@ -1,13 +1,27 @@
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 /**
- * Formats the date in a human-readable format
+ * Returns time, that has been passed from updated at timestamp
  * @param updatedAt - the date the note was last updated
  * @returns the last updated time
  */
-export function formatShortDate(updatedAt: string): string {
+export function getTimeFromNow(updatedAt: string): string {
   dayjs.extend(relativeTime);
   const formattedUpdatedAt = dayjs(updatedAt).fromNow();
 
   return formattedUpdatedAt;
+}
+
+/**
+ * Converts timestamp to readable time format
+ * @param date - date instance from timestamp
+ * @returns - string with formatted date and time
+ */
+export function parseDate(date: Date): string {
+  return new Intl.DateTimeFormat('en-GB', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  }).format(date);
 }

--- a/src/infrastructure/utils/parseDate.ts
+++ b/src/infrastructure/utils/parseDate.ts
@@ -1,0 +1,19 @@
+export function parseDate(date: Date): string {
+  // Массив с названиями месяцев
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+  // Получаем название месяца
+  const month = months[date.getUTCMonth()];
+
+  // Получаем день
+  const day = date.getUTCDate();
+
+  // Получаем часы и минуты, добавляем ведущий ноль при необходимости
+  const hours = date.getUTCHours().toString()
+    .padStart(2, '0');
+  const minutes = date.getUTCMinutes().toString()
+    .padStart(2, '0');
+
+  // Формируем итоговую строку
+  return `${month} ${day}, ${hours}:${minutes}`;
+}

--- a/src/infrastructure/utils/parseDate.ts
+++ b/src/infrastructure/utils/parseDate.ts
@@ -1,19 +1,8 @@
 export function parseDate(date: Date): string {
-  // Массив с названиями месяцев
-  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-
-  // Получаем название месяца
-  const month = months[date.getUTCMonth()];
-
-  // Получаем день
-  const day = date.getUTCDate();
-
-  // Получаем часы и минуты, добавляем ведущий ноль при необходимости
-  const hours = date.getUTCHours().toString()
-    .padStart(2, '0');
-  const minutes = date.getUTCMinutes().toString()
-    .padStart(2, '0');
-
-  // Формируем итоговую строку
-  return `${month} ${day}, ${hours}:${minutes}`;
+  return new Intl.DateTimeFormat('en-GB', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  }).format(date);
 }

--- a/src/infrastructure/utils/parseDate.ts
+++ b/src/infrastructure/utils/parseDate.ts
@@ -1,8 +1,0 @@
-export function parseDate(date: Date): string {
-  return new Intl.DateTimeFormat('en-GB', {
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-  }).format(date);
-}

--- a/src/presentation/components/note-list/NoteList.vue
+++ b/src/presentation/components/note-list/NoteList.vue
@@ -41,7 +41,7 @@
 <script setup lang="ts">
 import useNoteList from '@/application/services/useNoteList';
 import type { Note } from '@/domain/entities/Note';
-import { formatShortDate } from '@/infrastructure/utils/date';
+import { getTimeFromNow } from '@/infrastructure/utils/date';
 import { getTitle } from '@/infrastructure/utils/note';
 import { useI18n } from 'vue-i18n';
 import { Card, CardSkeleton, Button } from 'codex-ui/vue';
@@ -66,7 +66,7 @@ function getSubtitle(note: Note): string | undefined {
     return;
   }
 
-  return `${t('home.updated')} ${formatShortDate(note.updatedAt)}`;
+  return `${t('home.updated')} ${getTimeFromNow(note.updatedAt)}`;
 }
 
 </script>

--- a/src/presentation/pages/History.vue
+++ b/src/presentation/pages/History.vue
@@ -55,7 +55,7 @@ import ThreeColsLayout from '../layouts/ThreeColsLayout.vue';
 import useNoteHistory from '@/application/services/useNoteHistory';
 import useHeader from '@/application/services/useHeader';
 import useNote from '@/application/services/useNote';
-import { parseDate } from '@/infrastructure/utils/parseDate';
+import { parseDate } from '@/infrastructure/utils/date';
 import { watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { NoteId } from '@/domain/entities/Note';

--- a/src/presentation/pages/History.vue
+++ b/src/presentation/pages/History.vue
@@ -48,6 +48,7 @@
     </div>
   </ThreeColsLayout>
 </template>
+<!-- @todo Make button with icon Eye, it would be implemented in Codex icons 2.0 -->
 
 <script setup lang="ts">
 import { Heading, Container, Row, Avatar, Button } from 'codex-ui/vue';

--- a/src/presentation/pages/History.vue
+++ b/src/presentation/pages/History.vue
@@ -53,20 +53,38 @@
 import { Heading, Container, Row, Avatar, Button } from 'codex-ui/vue';
 import ThreeColsLayout from '../layouts/ThreeColsLayout.vue';
 import useNoteHistory from '@/application/services/useNoteHistory';
+import useHeader from '@/application/services/useHeader';
+import useNote from '@/application/services/useNote';
 import { parseDate } from '@/infrastructure/utils/parseDate';
-
-const props = defineProps({
-  noteId: Note['id'],
-});
-
-const { noteHistory } = useNoteHistory({ noteId: props.noteId });
-
+import { watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import Note from './Note.vue';
+import type { NoteId } from '@/domain/entities/Note';
+import { useRoute } from 'vue-router';
+
+const props = defineProps<{
+  /**
+   * Id of the note
+   */
+  noteId: NoteId;
+
+}>();
 
 const { t } = useI18n();
+const { noteHistory } = useNoteHistory({ noteId: props.noteId });
+const { patchOpenedPageByUrl } = useHeader();
 
-const noteTitle = 'HELLO WORLD HISTORY';
+const route = useRoute();
+
+const { noteTitle } = useNote({ id: props.noteId });
+
+watch(noteTitle, (currentNoteTitle) => {
+  patchOpenedPageByUrl(
+    route.path,
+    {
+      title: `Version hisotry (${currentNoteTitle})`,
+      url: route.path,
+    });
+});
 
 </script>
 <style lang="postcss" module>

--- a/src/presentation/pages/History.vue
+++ b/src/presentation/pages/History.vue
@@ -35,9 +35,9 @@
               />
             </template>
             <template #right>
+              <!-- @todo Make button with icon Eye, it would be implemented in Codex icons 2.0 -->
               <Button
                 secondary
-                icon="Search"
               >
                 {{ t('history.view') }}
               </Button>
@@ -48,7 +48,6 @@
     </div>
   </ThreeColsLayout>
 </template>
-<!-- @todo Make button with icon Eye, it would be implemented in Codex icons 2.0 -->
 
 <script setup lang="ts">
 import { Heading, Container, Row, Avatar, Button } from 'codex-ui/vue';

--- a/src/presentation/pages/History.vue
+++ b/src/presentation/pages/History.vue
@@ -1,0 +1,120 @@
+<template>
+  <ThreeColsLayout data-dimensions="large">
+    <div :class="$style['history']">
+      <div :class="$style['history__page-header']">
+        <Heading
+          :level="1"
+          :class="$style['title']"
+        >
+          {{ noteTitle }}
+        </Heading>
+        <Heading
+          :level="2"
+          :class="$style['subtle']"
+        >
+          {{ t('history.title') }}
+        </Heading>
+      </div>
+
+      <div :class="$style['history__container']">
+        <Container
+          :class="$style['history-items']"
+        >
+          <Row
+            v-for="(historyRecord, index) in noteHistory"
+            :key="historyRecord.id"
+            :title="historyRecord.user.name"
+            :subtitle="parseDate(new Date(historyRecord.createdAt))"
+            :has-delimiter="noteHistory !== null && index !== noteHistory?.length - 1"
+            :class="$style['history-items__row']"
+          >
+            <template #left>
+              <Avatar
+                :src="historyRecord.user.photo"
+                :username="historyRecord.user.name"
+              />
+            </template>
+            <template #right>
+              <Button
+                secondary
+                icon="Search"
+              >
+                {{ t('history.view') }}
+              </Button>
+            </template>
+          </Row>
+        </Container>
+      </div>
+    </div>
+  </ThreeColsLayout>
+</template>
+
+<script setup lang="ts">
+import { Heading, Container, Row, Avatar, Button } from 'codex-ui/vue';
+import ThreeColsLayout from '../layouts/ThreeColsLayout.vue';
+import useNoteHistory from '@/application/services/useNoteHistory';
+import { parseDate } from '@/infrastructure/utils/parseDate';
+
+const props = defineProps({
+  noteId: Note['id'],
+});
+
+const { noteHistory } = useNoteHistory({ noteId: props.noteId });
+
+import { useI18n } from 'vue-i18n';
+import Note from './Note.vue';
+
+const { t } = useI18n();
+
+const noteTitle = 'HELLO WORLD HISTORY';
+
+</script>
+<style lang="postcss" module>
+
+.history {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+
+  &__page-header {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-start;
+    gap: var(--spacing-s);
+    align-self: stretch;
+    padding: var(--spacing-xxl) var(--h-padding) 0;
+  }
+
+  &__container {
+    display: flex;
+    padding: var(--spacing-xxl) 0;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-start;
+    gap: var(--spacing-ml);
+    align-self: stretch;
+  }
+}
+
+.history-items {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+
+  &__row {
+    align-self: stretch;
+    color: var(--text);
+  }
+}
+
+.title {
+  color: var(--base--text);
+}
+
+.subtle {
+  color: var(--base--text-secondary);
+}
+
+</style>

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -6,7 +6,7 @@
       <template #left>
         {{
           note && 'updatedAt' in note && note.updatedAt
-            ? t('note.lastEdit') + ' ' + formatShortDate(note.updatedAt)
+            ? t('note.lastEdit') + ' ' + getTimeFromNow(note.updatedAt)
             : t('note.lastEdit') + ' ' + 'a few seconds ago'
         }}
       </template>
@@ -47,7 +47,7 @@ import { useRouter } from 'vue-router';
 import { NoteContent } from '@/domain/entities/Note';
 import { useHead } from 'unhead';
 import { useI18n } from 'vue-i18n';
-import { formatShortDate } from '@/infrastructure/utils/date';
+import { getTimeFromNow } from '@/infrastructure/utils/date';
 import { makeElementScreenshot } from '@/infrastructure/utils/screenshot';
 import useNoteSettings from '@/application/services/useNoteSettings';
 import { useNoteEditor } from '@/application/services/useNoteEditor';

--- a/src/presentation/pages/NoteSettings.vue
+++ b/src/presentation/pages/NoteSettings.vue
@@ -36,7 +36,7 @@
             <Card
               v-if="parentNote"
               :title="parentNoteTitle"
-              :subtitle="formatShortDate(parentNote.createdAt!)"
+              :subtitle="getTimeFromNow(parentNote.createdAt!)"
               orientation="horizontal"
             >
               <Button
@@ -108,7 +108,7 @@ import Team from '@/presentation/components/team/Team.vue';
 import { Section, Row, Switch, Button, Heading, Fieldset, Input, Card } from 'codex-ui/vue';
 import ThreeColsLayout from '@/presentation/layouts/ThreeColsLayout.vue';
 import { getTitle } from '@/infrastructure/utils/note';
-import { formatShortDate } from '@/infrastructure/utils/date';
+import { getTimeFromNow } from '@/infrastructure/utils/date';
 import InviteLink from '@/presentation/components/noteSettings/InviteLink.vue';
 
 const { t } = useI18n();


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d10116a8-6499-48ff-90b2-e31cf9fbbacb)

- added note history page
- added NoteHistory domain and application services
- added noteHistory repository
- added parseDate util

### Todo
- [x] add note title update for heading and for tab in tabbar
- [x] wait for codex icon 2.0 (icon `eye` needed) (left @todo for that)

Will make note history button in note page and note history record clickable in next PR