### PR TITLE
feat(note-history): implement history version page

### DIFF
--- a/codex-ui/package.json
+++ b/codex-ui/package.json
@@ -48,7 +48,7 @@
     "vue-tsc": "latest"
   },
   "dependencies": {
-    "@editorjs/editorjs": "2.30.2-rc.0",
+    "@editorjs/editorjs": "2.30.2",
     "vue": "^3.4.16"
   }
 }

--- a/src/application/i18n/messages/en.json
+++ b/src/application/i18n/messages/en.json
@@ -83,7 +83,9 @@
   },
   "history": {
     "title": "Versions history",
-    "view": "View"
+    "view": "View",
+    "useVersion": "Use this version",
+    "confirmVersionRestore": "Do you really want to use this version?"
   },
   "noteList": {
     "emptyNoteList": "No Notes yet. Make your first note",

--- a/src/application/i18n/messages/en.json
+++ b/src/application/i18n/messages/en.json
@@ -175,6 +175,7 @@
     "notFound": "Not found",
     "joinTeam": "Join",
     "authorization": "Authorize",
-    "history": "History"
+    "history": "History",
+    "historyVersion": "Version"
   }
 }

--- a/src/application/router/routes.ts
+++ b/src/application/router/routes.ts
@@ -10,6 +10,7 @@ import type { RouteRecordRaw } from 'vue-router';
 import AddTool from '@/presentation/pages/marketplace/AddTool.vue';
 import MarketplacePage from '@/presentation/pages/marketplace/MarketplacePage.vue';
 import History from '@/presentation/pages/History.vue';
+import HistoryVersion from '@/presentation/pages/HistoryVersion.vue';
 import MarketplaceTools from '@/presentation/pages/marketplace/MarketplaceTools.vue';
 
 // Default production hostname for homepage. If different, then custom hostname used
@@ -55,6 +56,20 @@ const routes: RouteRecordRaw[] = [
     },
     props: route => ({
       noteId: String(route.params.noteId),
+    }),
+  },
+  {
+    name: 'history_version',
+    path: '/note/:noteId/history/:historyId',
+    component: HistoryVersion,
+    meta: {
+      layout: 'fullpage',
+      pageTitleI18n: 'pages.historyVersion',
+      authRequired: true,
+    },
+    props: route => ({
+      noteId: String(route.params.noteId),
+      historyId: Number(route.params.historyId),
     }),
   },
   {

--- a/src/application/services/useNoteHistory.ts
+++ b/src/application/services/useNoteHistory.ts
@@ -59,21 +59,14 @@ export default function useNoteHistory(options: UseNoteHistoryComposableOptions)
    * When page is mounted, we should load note history
    */
   onMounted(async () => {
-    console.log('service mounted');
     if (currentNoteId.value !== null) {
       await loadNoteHistory(currentNoteId.value);
-      // if (notEmpty(currentHistoryId.value)) {
-      //   await loadNoteHistoryRecord(currentNoteId.value, currentHistoryId.value);
-      // }
     }
   });
 
   watch(currentHistoryId, async (historyId) => {
-    console.log('watcher');
     if (notEmpty(historyId) && currentNoteId.value !== null) {
-      console.log('loadinig started');
       await loadNoteHistoryRecord(currentNoteId.value, historyId);
-      console.log('loadinig awaited');
     }
   }, {
     immediate: true,

--- a/src/domain/entities/History.ts
+++ b/src/domain/entities/History.ts
@@ -57,3 +57,5 @@ export type NoteHistoryMeta = Omit<NoteHistoryRecord, 'content' | 'noteId' | 'to
    */
   user: UserMeta;
 };
+
+export type NoteHistoryView = NoteHistoryRecord & { user: UserMeta };

--- a/src/domain/noteHistory.repository.interface.ts
+++ b/src/domain/noteHistory.repository.interface.ts
@@ -1,4 +1,4 @@
-import type { NoteHistoryMeta, NoteHistoryRecord } from './entities/History';
+import type { NoteHistoryMeta, NoteHistoryRecord, NoteHistoryView } from './entities/History';
 import type { Note } from './entities/Note';
 
 /**
@@ -11,5 +11,5 @@ export default interface NoteHistoryRepositoryInterface {
    */
   loadNoteHistory(noteId: Note['id']): Promise<NoteHistoryMeta[]>;
 
-  getNoteHistoryRecordById(noteId: Note['id'], historyId: NoteHistoryRecord['id']): Promise<NoteHistoryRecord>;
+  getNoteHistoryRecordById(noteId: Note['id'], historyId: NoteHistoryRecord['id']): Promise<NoteHistoryView>;
 }

--- a/src/domain/noteHistory.repository.interface.ts
+++ b/src/domain/noteHistory.repository.interface.ts
@@ -1,4 +1,4 @@
-import type { NoteHistoryMeta } from './entities/History';
+import type { NoteHistoryMeta, NoteHistoryRecord } from './entities/History';
 import type { Note } from './entities/Note';
 
 /**
@@ -10,4 +10,6 @@ export default interface NoteHistoryRepositoryInterface {
    * @param noteId - id of the note
    */
   loadNoteHistory(noteId: Note['id']): Promise<NoteHistoryMeta[]>;
+
+  getNoteHistoryRecordById(noteId: Note['id'], historyId: NoteHistoryRecord['id']): Promise<NoteHistoryRecord>;
 }

--- a/src/domain/noteHistory.service.ts
+++ b/src/domain/noteHistory.service.ts
@@ -1,4 +1,4 @@
-import type { NoteHistoryMeta } from './entities/History';
+import type { NoteHistoryMeta, NoteHistoryRecord } from './entities/History';
 import type { Note } from './entities/Note';
 import type NoteHistoryRepository from './noteHistory.repository.interface';
 
@@ -22,5 +22,9 @@ export default class NoteHistoryService {
    */
   public async loadNoteHistory(noteId: Note['id']): Promise<NoteHistoryMeta[]> {
     return await this.noteHistoryRepository.loadNoteHistory(noteId);
+  }
+
+  public async getNoteHistoryRecordById(noteId: Note['id'], historyId: NoteHistoryRecord['id']): Promise<NoteHistoryRecord> {
+    return await this.noteHistoryRepository.getNoteHistoryRecordById(noteId, historyId);
   }
 }

--- a/src/domain/noteHistory.service.ts
+++ b/src/domain/noteHistory.service.ts
@@ -1,4 +1,4 @@
-import type { NoteHistoryMeta, NoteHistoryRecord } from './entities/History';
+import type { NoteHistoryMeta, NoteHistoryRecord, NoteHistoryView } from './entities/History';
 import type { Note } from './entities/Note';
 import type NoteHistoryRepository from './noteHistory.repository.interface';
 
@@ -24,7 +24,7 @@ export default class NoteHistoryService {
     return await this.noteHistoryRepository.loadNoteHistory(noteId);
   }
 
-  public async getNoteHistoryRecordById(noteId: Note['id'], historyId: NoteHistoryRecord['id']): Promise<NoteHistoryRecord> {
+  public async getNoteHistoryRecordById(noteId: Note['id'], historyId: NoteHistoryRecord['id']): Promise<NoteHistoryView> {
     return await this.noteHistoryRepository.getNoteHistoryRecordById(noteId, historyId);
   }
 }

--- a/src/infrastructure/noteHistory.repository.ts
+++ b/src/infrastructure/noteHistory.repository.ts
@@ -1,7 +1,7 @@
 import type NoteHistoryRepositoryInterface from '@/domain/noteHistory.repository.interface';
 import type NotesApiTransport from './transport/notes-api';
 import type { Note } from '@/domain/entities/Note';
-import type { NoteHistoryMeta } from '@/domain/entities/History';
+import type { NoteHistoryMeta, NoteHistoryRecord } from '@/domain/entities/History';
 
 /**
  * Note history repository class used for data delivery from transport to service
@@ -24,5 +24,11 @@ export default class NoteHistoryRepository implements NoteHistoryRepositoryInter
     const response = await this.transport.get<{ noteHistoryMeta: NoteHistoryMeta[] }>(`/note/${noteId}/history`);
 
     return response.noteHistoryMeta;
+  }
+
+  public async getNoteHistoryRecordById(noteId: Note['id'], historyId: NoteHistoryRecord['id']): Promise<NoteHistoryRecord> {
+    const response = await this.transport.get<{ noteHistoryRecord: NoteHistoryRecord }>(`/note/${noteId}/history/${historyId}`);
+
+    return response.noteHistoryRecord;
   }
 }

--- a/src/presentation/pages/AuthorizationPage.vue
+++ b/src/presentation/pages/AuthorizationPage.vue
@@ -4,7 +4,7 @@
     <Button
       @click="showGoogleAuthPopup"
     >
-     {{ t('auth.login') }}
+      {{ t('auth.login') }}
     </Button>
   </div>
 </template>

--- a/src/presentation/pages/History.vue
+++ b/src/presentation/pages/History.vue
@@ -83,7 +83,7 @@ watch(noteTitle, (currentNoteTitle) => {
   patchOpenedPageByUrl(
     route.path,
     {
-      title: `Version hisotry (${currentNoteTitle})`,
+      title: `Version history (${currentNoteTitle})`,
       url: route.path,
     });
 });
@@ -114,7 +114,6 @@ watch(noteTitle, (currentNoteTitle) => {
     align-items: flex-start;
     gap: var(--spacing-ml);
     align-self: stretch;
-    cursor: pointer;
   }
 }
 
@@ -123,6 +122,7 @@ watch(noteTitle, (currentNoteTitle) => {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  cursor: pointer;
 
   &__row {
     align-self: stretch;

--- a/src/presentation/pages/History.vue
+++ b/src/presentation/pages/History.vue
@@ -27,6 +27,7 @@
             :subtitle="parseDate(new Date(historyRecord.createdAt))"
             :has-delimiter="noteHistory !== null && index !== noteHistory?.length - 1"
             :class="$style['history-items__row']"
+            @click="router.push(`/note/${props.noteId}/history/${historyRecord.id}`)"
           >
             <template #left>
               <Avatar
@@ -59,7 +60,7 @@ import { parseDate } from '@/infrastructure/utils/date';
 import { watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { NoteId } from '@/domain/entities/Note';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 
 const props = defineProps<{
   /**
@@ -74,6 +75,7 @@ const { noteHistory } = useNoteHistory({ noteId: props.noteId });
 const { patchOpenedPageByUrl } = useHeader();
 
 const route = useRoute();
+const router = useRouter();
 
 const { noteTitle } = useNote({ id: props.noteId });
 
@@ -112,6 +114,7 @@ watch(noteTitle, (currentNoteTitle) => {
     align-items: flex-start;
     gap: var(--spacing-ml);
     align-self: stretch;
+    cursor: pointer;
   }
 }
 

--- a/src/presentation/pages/HistoryVersion.vue
+++ b/src/presentation/pages/HistoryVersion.vue
@@ -1,0 +1,54 @@
+<template>
+  Privet
+  {{ historyContent }}
+  {{ historyId }}
+  <Editor
+    v-if="isEditorReady"
+    ref="editor"
+    v-bind="editorConfig"
+  />
+</template>
+
+<script lang="ts" setup>
+import { ref, toRef, watch } from 'vue';
+import { until } from '@vueuse/core';
+import { Editor } from 'codex-ui/vue';
+import useHistory from '@/application/services/useNoteHistory';
+import { useNoteEditor } from '@/application/services/useNoteEditor';
+
+const props = defineProps<{
+  noteId: string;
+  historyId: number;
+}>();
+
+const noteId = toRef(props, 'noteId');
+const historyId = toRef(props, 'historyId');
+
+const { historyContent, historyTools } = useHistory({
+  noteId: noteId,
+  historyId: historyId,
+});
+
+const canEdit = ref(false);
+
+watch(historyContent, async (c) => {
+  console.log('new content', c);
+  await until(c).not.toBe(undefined);
+  console.log('new content awaited', c);
+}, {
+  immediate: true,
+});
+
+const { isEditorReady, editorConfig } = useNoteEditor({
+  noteTools: historyTools,
+  isDraftResolver: () => noteId.value === null,
+  noteContentResolver: () => historyContent.value,
+  canEdit,
+});
+
+console.log('editor used', historyContent.value);
+
+</script>
+
+<style scoped>
+</style>

--- a/src/presentation/pages/HistoryVersion.vue
+++ b/src/presentation/pages/HistoryVersion.vue
@@ -1,32 +1,65 @@
 <template>
-  Privet
-  {{ historyContent }}
-  {{ historyId }}
-  <Editor
-    v-if="isEditorReady"
-    ref="editor"
-    v-bind="editorConfig"
-  />
+  <div>
+    <NoteHeader>
+      <template #left>
+        {{
+          historyMeta && 'createdAt' in historyMeta && historyMeta.createdAt
+            ? t('note.lastEdit') + ' ' + getTimeFromNow(historyMeta.createdAt)
+            : t('note.lastEdit') + ' ' + 'a few seconds ago'
+        }}
+      </template>
+      <template #right>
+        <!-- @todo add icon history to the button, it will be availible since codex icons 2.0 -->
+        <Button
+          secondary
+          @click="router.push(`/note/${noteId}/history`)"
+        >
+          history
+        </Button>
+      </template>
+    </NoteHeader>
+    <Editor
+      v-if="isEditorReady"
+      ref="editor"
+      v-bind="editorConfig"
+    />
+  </div>
 </template>
 
 <script lang="ts" setup>
 import { ref, toRef, watch } from 'vue';
 import { until } from '@vueuse/core';
-import { Editor } from 'codex-ui/vue';
+import { Editor, Button } from 'codex-ui/vue';
+import NoteHeader from '@/presentation/components/note-header/NoteHeader.vue';
 import useHistory from '@/application/services/useNoteHistory';
 import { useNoteEditor } from '@/application/services/useNoteEditor';
+import { getTimeFromNow, parseDate } from '@/infrastructure/utils/date';
+import useNote from '@/application/services/useNote';
+import { useI18n } from 'vue-i18n';
+import useHeader from '@/application/services/useHeader';
+import { useRoute, useRouter } from 'vue-router';
 
 const props = defineProps<{
   noteId: string;
   historyId: number;
 }>();
 
+const { t } = useI18n();
+const { patchOpenedPageByUrl } = useHeader();
+
+const route = useRoute();
+const router = useRouter();
+
 const noteId = toRef(props, 'noteId');
 const historyId = toRef(props, 'historyId');
 
-const { historyContent, historyTools } = useHistory({
+const { historyContent, historyTools, historyMeta } = useHistory({
   noteId: noteId,
   historyId: historyId,
+});
+
+const { noteTitle } = useNote({
+  id: noteId,
 });
 
 const canEdit = ref(false);
@@ -37,6 +70,17 @@ watch(historyContent, async (c) => {
   console.log('new content awaited', c);
 }, {
   immediate: true,
+});
+
+watch(noteTitle, (currentNoteTitle) => {
+  if (historyMeta.value?.createdAt) {
+    patchOpenedPageByUrl(
+      route.path,
+      {
+        title: `Version ${parseDate(new Date(historyMeta.value?.createdAt))} (${currentNoteTitle})`,
+        url: route.path,
+      });
+  }
 });
 
 const { isEditorReady, editorConfig } = useNoteEditor({

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -17,6 +17,14 @@
           icon="Plus"
           @click="createChildNote"
         />
+        <!-- @todo add icon history to the button, it will be availible since codex icons 2.0 -->
+        <Button
+          v-if="canEdit"
+          secondary
+          @click="router.push(`/note/${noteId}/history`)"
+        >
+          history
+        </Button>
         <Button
           v-if="canEdit"
           secondary

--- a/yarn.lock
+++ b/yarn.lock
@@ -510,10 +510,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@editorjs/editorjs@npm:2.30.2-rc.0":
-  version: 2.30.2-rc.0
-  resolution: "@editorjs/editorjs@npm:2.30.2-rc.0"
-  checksum: 192af217036b7dcb36050361d36a99d287cb572dc5ed64fe6657928d0bd9c82c750970ef477cc85c5baebb4e4cae591bbd72b9fd7e669832c279cce48a70854b
+"@editorjs/editorjs@npm:2.30.2":
+  version: 2.30.2
+  resolution: "@editorjs/editorjs@npm:2.30.2"
+  checksum: 658e10918390d18578e65d73e84f601b7eab8ba1a704142872a597ed0da6bb1ee407fc32b5b18a473a99c993729dc8959df408f10738a6150199acaf225474fc
   languageName: node
   linkType: hard
 
@@ -2166,7 +2166,7 @@ __metadata:
   resolution: "codex-ui@workspace:codex-ui"
   dependencies:
     "@codexteam/icons": ^0.3.0
-    "@editorjs/editorjs": 2.30.2-rc.0
+    "@editorjs/editorjs": 2.30.2
     "@editorjs/header": ^2.8.6
     "@editorjs/nested-list": ^1.4.2
     "@types/node": ^20.11.15


### PR DESCRIPTION
- added history version page
![image](https://github.com/user-attachments/assets/96b5f594-9daf-4a5a-8189-e7d65e623a30)
- added history entry in the note
![image](https://github.com/user-attachments/assets/87c8e238-8c65-45b7-88ff-432081217201)
- now hisotry records are clickable