### PR TITLE
fix(tabbar): issue of tabbar duplicate of note setting fixed

### DIFF
--- a/src/application/i18n/messages/en.json
+++ b/src/application/i18n/messages/en.json
@@ -44,6 +44,7 @@
   },
   "noteSettings": {
     "title": "Note Settings",
+    "settings": "Settings",
     "customHostname": "Custom Hostname",
     "hostnamePlaceholder": "example: landing.codex.so",
     "availabilityTitle": "Availability",

--- a/src/presentation/pages/NoteSettings.vue
+++ b/src/presentation/pages/NoteSettings.vue
@@ -210,7 +210,7 @@ useHead({
 
 watch(noteTitle, (newTitle) => {
   const openPageInfo = {
-    title: `${t('Settings')} (${newTitle})`,
+    title: `${t('noteSettings.settings')} (${newTitle})`,
     url: route.path,
   };
 

--- a/src/presentation/pages/NoteSettings.vue
+++ b/src/presentation/pages/NoteSettings.vue
@@ -210,7 +210,7 @@ useHead({
 
 watch(noteTitle, (newTitle) => {
   const openPageInfo = {
-    title: `Note Settings (${newTitle})`,
+    title: `${t('Settings')} (${newTitle})`,
     url: route.path,
   };
 

--- a/src/presentation/pages/NoteSettings.vue
+++ b/src/presentation/pages/NoteSettings.vue
@@ -205,7 +205,7 @@ function getParentURL(id: NoteId | undefined): string {
  * Changing the title in the browser
  */
 useHead({
-  title: 'Note Settings',
+  title: t('noteSettings.title'),
 });
 
 watch(noteTitle, (newTitle) => {

--- a/src/presentation/pages/NoteSettings.vue
+++ b/src/presentation/pages/NoteSettings.vue
@@ -102,7 +102,7 @@ import useNoteSettings from '@/application/services/useNoteSettings';
 import useNote from '@/application/services/useNote';
 import { useHead } from 'unhead';
 import { useI18n } from 'vue-i18n';
-import { computed, ref, onMounted } from 'vue';
+import { computed, ref, onMounted, watch } from 'vue';
 import { useDebounceFn } from '@vueuse/core';
 import Team from '@/presentation/components/team/Team.vue';
 import { Section, Row, Switch, Button, Heading, Fieldset, Input, Card } from 'codex-ui/vue';
@@ -110,6 +110,8 @@ import ThreeColsLayout from '@/presentation/layouts/ThreeColsLayout.vue';
 import { getTitle } from '@/infrastructure/utils/note';
 import { getTimeFromNow } from '@/infrastructure/utils/date';
 import InviteLink from '@/presentation/components/noteSettings/InviteLink.vue';
+import useHeader from '@/application/services/useHeader';
+import { useRoute } from 'vue-router';
 
 const { t } = useI18n();
 
@@ -120,6 +122,8 @@ const props = defineProps<{
   id: NoteId;
 }>();
 
+const { patchOpenedPageByUrl } = useHeader();
+const route = useRoute();
 const { noteSettings, load: loadSettings, updateIsPublic, deleteNoteById, parentNote, setParent } = useNoteSettings();
 const { noteTitle, unlinkParent } = useNote({
   id: props.id,
@@ -201,7 +205,16 @@ function getParentURL(id: NoteId | undefined): string {
  * Changing the title in the browser
  */
 useHead({
-  title: t('noteSettings.title'),
+  title: 'Note Settings',
+});
+
+watch(noteTitle, (newTitle) => {
+  const openPageInfo = {
+    title: `Note Settings (${newTitle})`,
+    url: route.path,
+  };
+
+  patchOpenedPageByUrl(route.path, openPageInfo);
 });
 
 onMounted(async () => {


### PR DESCRIPTION
## Problem: Issue #269 
For now Note settings title in tabbar duplicates note title

## Solution:
- Naming the tabbar `Note Settings` , and add watcher for noteTitle variable from UseNote() app service.
- Use patchOpenedPageByUrl() method from UseHeader() app service for patching title of note settings in tabbar.