### PR TITLE
fix(&nbsp): a bug of header contains the &nbsp fixed

### DIFF
--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -147,7 +147,7 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
     if (!firstNoteBlock || !Boolean(firstNoteBlock.data.text)) {
       return 'Note';
     } else {
-      return firstNoteBlock.data.text.slice(0, limitCharsForNoteTitle);
+      return firstNoteBlock.data.text.replace(/&nbsp;/g, ' ').slice(0, limitCharsForNoteTitle);
     }
   });
 

--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -129,8 +129,6 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
 
   const route = useRoute();
 
-  // const limitCharsForNoteTitle = 50;
-
   /**
    * Is there any note currently saving
    * Used to prevent re-load note after draft is saved

--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -6,6 +6,7 @@ import { useRouter, useRoute } from 'vue-router';
 import type { NoteDraft } from '@/domain/entities/NoteDraft';
 import type EditorTool from '@/domain/entities/EditorTool';
 import useHeader from './useHeader';
+import { getTitle } from '@/infrastructure/utils/note';
 
 /**
  * Creates base structure for the empty note:
@@ -128,7 +129,7 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
 
   const route = useRoute();
 
-  const limitCharsForNoteTitle = 50;
+  // const limitCharsForNoteTitle = 50;
 
   /**
    * Is there any note currently saving
@@ -142,13 +143,7 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
   const noteTitle = computed(() => {
     const noteContent = lastUpdateContent.value ?? note.value?.content;
 
-    const firstNoteBlock = noteContent?.blocks[0];
-
-    if (!firstNoteBlock || !Boolean(firstNoteBlock.data.text)) {
-      return 'Note';
-    } else {
-      return firstNoteBlock.data.text.replace(/&nbsp;/g, ' ').slice(0, limitCharsForNoteTitle);
-    }
+    return getTitle(noteContent);
   });
 
   /**

--- a/src/infrastructure/utils/note.ts
+++ b/src/infrastructure/utils/note.ts
@@ -18,7 +18,7 @@ export function getTitle(content: OutputData): string {
   if (text === undefined || text.trim() === '') {
     return t('note.untitled');
   } else {
-    return text?.slice?.(0, limitCharsForNoteTitle);
+    return text?.replace(/&nbsp;/g, ' ')?.slice?.(0, limitCharsForNoteTitle);
   }
 }
 

--- a/src/infrastructure/utils/note.ts
+++ b/src/infrastructure/utils/note.ts
@@ -1,22 +1,20 @@
 import { type OutputData } from '@editorjs/editorjs';
-import { useI18n } from 'vue-i18n';
 /**
  * Get the title of the note
  * @param content - content of the note
  * @returns the title of the note
  */
-export function getTitle(content: OutputData): string {
+export function getTitle(content: OutputData | undefined): string {
   const limitCharsForNoteTitle = 50;
-  const firstNoteBlock = content.blocks[0];
-  const { t } = useI18n();
+  const firstNoteBlock = content?.blocks[0];
 
-  const text: string | undefined = firstNoteBlock.data.text;
+  const text: string | undefined = firstNoteBlock?.data.text;
 
   /**
    *  If the heading is empty, return 'Untitled'
    */
   if (text === undefined || text.trim() === '') {
-    return t('note.untitled');
+    return 'Untitled';
   } else {
     return text?.replace(/&nbsp;/g, ' ')?.slice?.(0, limitCharsForNoteTitle);
   }


### PR DESCRIPTION
## Problem:
When the first input in the note contains spaces, the header of the note show `&nbsp;`. 
resolves #257 

## Cause:
The noteContent get stored as HTML entity. For this reason, the title shows the `&nbsp;`, whenever there is occurrence of space in the first block of the note.

## Solution:
- Target the return value of function in `useNote` service and replace all occurrences of `&nbsp;` with space.
- The change was made also on the `NoteList` where the bug occurs too.