### PR TITLE
feat: select component integration

### DIFF
--- a/codex-ui/dev/pages/components/Select.vue
+++ b/codex-ui/dev/pages/components/Select.vue
@@ -5,27 +5,73 @@
       Component of the form that allows you to select one or more options from the list (currently one)
     </template>
   </PageHeader>
-  <Select
-    :items="options"
-    :default-item="defaultItem"
-    @value-update="(value) => updatedValue = value"
-  />
-  <Heading :level="3">
+  <div class="ex">
+    Default
+    <Select
+      v-model="currentItem"
+      :align="{vertically: 'below', horizontally: 'left'}"
+      :is-disabled="false"
+      :items="options"
+    />
+    Disabled
+    <Select
+      v-model="currentItem"
+      :align="{vertically: 'below', horizontally: 'left'}"
+      :is-disabled="true"
+      :items="options"
+    />
+  </div>
+  <Heading :level="2">
     Getting selected option
   </Heading>
-  You can use selected item outside the component via <code>@value-update</code>: <i>{{ updatedValue }}</i>
+  Selected option replaces default value and can be easily got from the same object:
+  <div class="ex">
+    <i>{{ currentItem }}</i>
+  </div>
+  <Heading
+    :level="2"
+  >
+    Aligning
+  </Heading>
+  You can choose vertical aligning from <code>below</code> and <code>above</code> and horizontal aligning from <code>left</code> and <code>right</code>
+  <div class="ex">
+    <Select
+      v-model="currentItem"
+      :align="{vertically: 'below', horizontally: 'left'}"
+      :is-disabled="false"
+      :items="options"
+    />
+    <Select
+      v-model="currentItem"
+      :align="{vertically: 'below', horizontally: 'right'}"
+      :is-disabled="false"
+      :items="options"
+    />
+    <Select
+      v-model="currentItem"
+      :align="{vertically: 'above', horizontally: 'left'}"
+      :is-disabled="false"
+      :items="options"
+    />
+    <Select
+      v-model="currentItem"
+      :align="{vertically: 'above', horizontally: 'right'}"
+      :is-disabled="false"
+      :items="options"
+    />
+  </div>
 </template>
 
 <script setup lang="ts">
 import PageHeader from '../../components/PageHeader.vue';
-import { ContextMenuItem, DefaultItem, Heading, Select } from '../../../src';
+import { ContextMenuItem, Heading, Select } from '../../../src';
 import { ref } from 'vue';
 
-const defaultItem: DefaultItem = {
+const currentItem = ref({
   title: 'Choose an option',
   onActivate: () => {},
-};
-const updatedValue = ref<DefaultItem>(defaultItem);
+});
+
 const options: ContextMenuItem[] = [
   {
     type: 'default',
@@ -57,4 +103,11 @@ const options: ContextMenuItem[] = [
 </script>
 
 <style scoped>
+.ex {
+  display: grid;
+  gap: var(--spacing-xl);
+  margin: var(--spacing-xl) 0 var(--spacing-xxl);
+  grid-template-columns: repeat(2, max-content);
+  align-items: center;
+}
 </style>

--- a/codex-ui/dev/pages/components/Select.vue
+++ b/codex-ui/dev/pages/components/Select.vue
@@ -8,17 +8,24 @@
   <Select
     :items="options"
     :default-item="defaultItem"
+    @value-update="(value) => updatedValue = value"
   />
+  <Heading :level="3">
+    Getting selected option
+  </Heading>
+  You can use selected item outside the component via <code>@value-update</code>: <i>{{ updatedValue }}</i>
 </template>
 
 <script setup lang="ts">
 import PageHeader from '../../components/PageHeader.vue';
-import { ContextMenuItem, DefaultItem, Select } from '../../../src';
+import { ContextMenuItem, DefaultItem, Heading, Select } from '../../../src';
+import { ref } from 'vue';
 
 const defaultItem: DefaultItem = {
   title: 'Choose an option',
   onActivate: () => {},
 };
+const updatedValue = ref<DefaultItem>(defaultItem);
 const options: ContextMenuItem[] = [
   {
     type: 'default',

--- a/codex-ui/src/vue/components/popover/Popover.vue
+++ b/codex-ui/src/vue/components/popover/Popover.vue
@@ -3,12 +3,6 @@
     v-show="isOpen"
     ref="popoverEl"
     :class="$style.popover"
-    :style="{
-      left: position.left + 'px',
-      top: position.top + 'px',
-      transform: position.transform,
-      width: width + 'px' // Assuming width is in pixels
-    }"
   >
     <component
       :is="content.component"
@@ -58,5 +52,9 @@ onClickOutside(popoverEl, hide, {
   border: 1px solid var(--base--border);
   padding: var(--h-padding);
   box-sizing: border-box;
+  left: v-bind('position.left');
+  top: v-bind('position.top');
+  transform: v-bind('position.transform');
+  width: v-bind('width');
 }
 </style>

--- a/codex-ui/src/vue/components/popover/Popover.vue
+++ b/codex-ui/src/vue/components/popover/Popover.vue
@@ -3,6 +3,12 @@
     v-show="isOpen"
     ref="popoverEl"
     :class="$style.popover"
+    :style="{
+      left: position.left + 'px',
+      top: position.top + 'px',
+      transform: position.transform,
+      width: width + 'px' // Assuming width is in pixels
+    }"
   >
     <component
       :is="content.component"
@@ -51,10 +57,6 @@ onClickOutside(popoverEl, hide, {
   border-radius: var(--radius-field);
   border: 1px solid var(--base--border);
   padding: var(--h-padding);
-  left: v-bind('position.left');
-  top: v-bind('position.top');
-  transform: v-bind('position.transform');
-  width: v-bind('width');
   box-sizing: border-box;
 }
 </style>

--- a/codex-ui/src/vue/components/popover/usePopover.ts
+++ b/codex-ui/src/vue/components/popover/usePopover.ts
@@ -36,8 +36,8 @@ export const usePopover = createSharedComposable(() => {
    * Popover position info used in the Popover component
    */
   const position = reactive({
-    left: 0,
-    top: 0,
+    left: '0px',
+    top: '0px',
     transform: 'translate(0, 0)',
   });
 
@@ -68,29 +68,29 @@ export const usePopover = createSharedComposable(() => {
 
     const rect = targetEl.getBoundingClientRect();
 
-    let top = 0;
-    let left = 0;
+    let top = '0px';
+    let left = '0px';
     let transformX = '0';
     let transformY = '0';
 
     switch (align.vertically) {
       case 'above':
-        top = rect.top - MARGIN + window.scrollY;
+        top = `${rect.top - MARGIN + window.scrollY}px`;
         transformY = '-100%';
         break;
       case 'below':
-        top = rect.bottom + MARGIN + window.scrollY;
+        top = `${rect.bottom + MARGIN + window.scrollY}px`;
         transformY = '0';
         break;
     }
 
     switch (align.horizontally) {
       case 'left':
-        left = rect.left;
+        left = `${rect.left}px`;
         transformX = '0';
         break;
       case 'right':
-        left = rect.right;
+        left = `${rect.right}px`;
         transformX = '-100';
         break;
     }
@@ -145,8 +145,8 @@ export const usePopover = createSharedComposable(() => {
   function resetPopover(): void {
     targetElement.value = null;
     content.value = null;
-    position.left = 0;
-    position.top = 0;
+    position.left = '0px';
+    position.top = '0px';
     position.transform = 'translate(0, 0)';
 
     isOpen.value = false;

--- a/codex-ui/src/vue/components/select/Select.vue
+++ b/codex-ui/src/vue/components/select/Select.vue
@@ -15,6 +15,7 @@ import { onMounted, ref } from 'vue';
 import { usePopover, PopoverShowParams } from '../popover';
 import { Button } from '../button';
 
+const emit = defineEmits(['valueUpdate']);
 const props = defineProps<{
   items: SelectItem[];
   defaultItem: DefaultItem;
@@ -45,8 +46,11 @@ const defaultValue: SelectItem = props.defaultItem;
 const activeItem = ref(defaultValue);
 
 /* Main function to update selected item */
+/* Also creates new event, which could be caught outside */
+
 const updateActiveItem = (item: DefaultItem) => {
   activeItem.value = item;
+  emit('valueUpdate', activeItem.value);
   hide();
 };
 

--- a/codex-ui/src/vue/components/select/Select.vue
+++ b/codex-ui/src/vue/components/select/Select.vue
@@ -1,31 +1,33 @@
 <template>
   <Button
-    :icon="activeItem.icon"
+    :icon="currentItem.icon"
+    :disabled="isDisabled"
     trailing-icon="BracketsVertical"
     secondary
-    @click="togglePopover($event.currentTarget, {vertically: 'below', horizontally: 'left'})"
+    @click="togglePopover($event.currentTarget)"
   >
-    {{ activeItem.title }}
+    {{ currentItem.title }}
   </Button>
 </template>
 <script setup lang="ts">
 import type { ContextMenuItem as SelectItem, DefaultItem } from '../context-menu/ContextMenu.types';
 import { ContextMenu } from '../context-menu';
-import { onMounted, ref } from 'vue';
+import { onMounted } from 'vue';
 import { usePopover, PopoverShowParams } from '../popover';
 import { Button } from '../button';
 
-const emit = defineEmits(['valueUpdate']);
 const props = defineProps<{
+  align: PopoverShowParams['align'];
+  isDisabled: boolean;
   items: SelectItem[];
-  defaultItem: DefaultItem;
 }>();
 
+const align = props.align;
 const items = props.items;
 const { showPopover, hide, isOpen } = usePopover();
 
-const togglePopover = (el: HTMLElement, align: PopoverShowParams['align']) => {
-  if (!isOpen.value) {
+const togglePopover = (el: HTMLElement) => {
+  if (!isOpen.value && !props.isDisabled) {
     showPopover({
       targetEl: el,
       with: {
@@ -42,15 +44,11 @@ const togglePopover = (el: HTMLElement, align: PopoverShowParams['align']) => {
 };
 
 /* Default item value for select on page load */
-const defaultValue: SelectItem = props.defaultItem;
-const activeItem = ref(defaultValue);
+const currentItem = defineModel<DefaultItem>({ required: true });
 
 /* Main function to update selected item */
-/* Also creates new event, which could be caught outside */
-
 const updateActiveItem = (item: DefaultItem) => {
-  activeItem.value = item;
-  emit('valueUpdate', activeItem.value);
+  currentItem.value = item;
   hide();
 };
 

--- a/src/domain/entities/Note.ts
+++ b/src/domain/entities/Note.ts
@@ -52,5 +52,8 @@ export interface Note {
    */
   updatedAt?: string;
 
+  /**
+   * Id of user, who created the note
+   */
   creatorId?: number;
 }

--- a/src/domain/entities/Note.ts
+++ b/src/domain/entities/Note.ts
@@ -51,4 +51,6 @@ export interface Note {
    * @todo Resolve the optionality issue
    */
   updatedAt?: string;
+
+  creatorId?: number;
 }

--- a/src/presentation/components/team/RoleSelect.vue
+++ b/src/presentation/components/team/RoleSelect.vue
@@ -1,17 +1,10 @@
 <template>
   <div v-if="teamMember.user.id != user?.id">
-    <select
-      v-model="selectedRole"
-      @change="updateMemberRole"
-    >
-      <option
-        v-for="(role, index) in roleOptions"
-        :key="index"
-        :value="role"
-      >
-        {{ t(`noteSettings.team.roles.${role}`) }}
-      </option>
-    </select>
+    <Select
+      :items="roleItems"
+      :default-item="defaultRole"
+      @value-update="(updatedRole) => updateMemberRole(updatedRole)"
+    />
   </div>
 </template>
 
@@ -22,6 +15,7 @@ import { computed, ref } from 'vue';
 import useNoteSettings from '@/application/services/useNoteSettings.ts';
 import { useAppState } from '@/application/services/useAppState';
 import { useI18n } from 'vue-i18n';
+import { ContextMenuItem, DefaultItem, Select } from 'codex-ui/vue';
 
 /**
  * TeamMember props
@@ -38,8 +32,20 @@ const props = defineProps<{
 }>();
 
 const selectedRole = ref(MemberRole[props.teamMember.role]);
+const defaultRole: DefaultItem = {
+  title: selectedRole.value,
+  onActivate: () => {},
+};
 
 const roleOptions = computed(() => Object.values(MemberRole).filter(value => typeof value === 'string'));
+const roleItems: ContextMenuItem[] = [];
+
+roleOptions.value.forEach((role) => {
+  roleItems.push({
+    title: role.toString(),
+    onActivate: () => {},
+  });
+});
 
 const { changeRole } = useNoteSettings();
 
@@ -50,8 +56,8 @@ const { t } = useI18n();
 /**
  * Updates the user role if it has been changed
  */
-async function updateMemberRole() {
-  changeRole(props.noteId, props.teamMember.user.id, MemberRole[selectedRole.value as keyof typeof MemberRole]);
+async function updateMemberRole(updatedRole: DefaultItem | any) {
+  changeRole(props.noteId, props.teamMember.user.id, MemberRole[updatedRole.title as keyof typeof MemberRole]);
 }
 </script>
 

--- a/src/presentation/components/team/RoleSelect.vue
+++ b/src/presentation/components/team/RoleSelect.vue
@@ -14,7 +14,6 @@ import { NoteId } from '@/domain/entities/Note.ts';
 import { computed, ref } from 'vue';
 import useNoteSettings from '@/application/services/useNoteSettings.ts';
 import { useAppState } from '@/application/services/useAppState';
-import { useI18n } from 'vue-i18n';
 import { ContextMenuItem, DefaultItem, Select } from 'codex-ui/vue';
 
 /**
@@ -51,10 +50,10 @@ const { changeRole } = useNoteSettings();
 
 const { user } = useAppState();
 
-const { t } = useI18n();
-
 /**
  * Updates the user role if it has been changed
+ *
+ * @param updatedRole - new role needed to set
  */
 async function updateMemberRole(updatedRole: DefaultItem | any) {
   changeRole(props.noteId, props.teamMember.user.id, MemberRole[updatedRole.title as keyof typeof MemberRole]);

--- a/src/presentation/components/team/RoleSelect.vue
+++ b/src/presentation/components/team/RoleSelect.vue
@@ -52,10 +52,8 @@ const { note } = useNote({ id: props.noteId });
 const { user } = useAppState();
 
 /* Watch role's update */
-watch(selectedRole, (newRole, oldRole) => {
-  if (newRole.title !== oldRole.title) {
-    updateMemberRole(newRole.title);
-  }
+watch(selectedRole, (newRole) => {
+  updateMemberRole(newRole.title);
 });
 /**
  * Updates the user role if it has been changed

--- a/src/presentation/components/team/Team.vue
+++ b/src/presentation/components/team/Team.vue
@@ -8,6 +8,7 @@
       :key="member.id"
       :title="member.user.name || member.user.email"
       :has-delimiter="memberIndex !== team.length - 1"
+      data-dimensions="medium"
     >
       <template #right>
         <RoleSelect


### PR DESCRIPTION
By this update Select Component was integrated into note's settings into Role Select component, which fixes #284. Due to this integration, some other little issues were fixed:
- added ability to get selected value outside the component via @value-update attribute
- changed Popover's reactive styling to avoid unapplying component's positioning
- Updated Select Component's page in Playground