### PR TITLE
Removed home page special permissions

### DIFF
--- a/src/application/i18n/messages/en.json
+++ b/src/application/i18n/messages/en.json
@@ -7,7 +7,6 @@
   },
   "header": {
     "buttons": {
-      "home": "Home",
       "noteSettings": "Settings"
     }
   },
@@ -176,7 +175,6 @@
     }
   },
   "pages": {
-    "home": "Home",
     "note": "Note",
     "newNote": "New note",
     "landing": "landing",

--- a/src/application/services/useNavbar.ts
+++ b/src/application/services/useNavbar.ts
@@ -29,7 +29,7 @@ interface useNavbarComposableState {
   patchOpenedPageByUrl: (url: OpenedPage['url'], page: OpenedPage) => void;
 
   /**
-   * Delete all opened pages excluding Home page
+   * Delete all opened pages
    */
   deleteOpenedPages: () => void;
 
@@ -77,7 +77,7 @@ export default function useNavbar(): useNavbarComposableState {
   };
 
   /**
-   * Delete all opened pages excluding Home page
+   * Delete all opened pages
    */
   function deleteOpenedPages(): void {
     workspaceService.deleteOpenedPages();
@@ -94,8 +94,13 @@ export default function useNavbar(): useNavbarComposableState {
       deleteOpenedPageByUrl(route.path);
     }
 
-    addOpenedPage({ title: t(currentRoute.meta.pageTitleI18n),
-      url: currentRoute.path });
+    /**
+     * If the route is '/' do not add the page
+     */
+    if (currentRoute.path !== '/') {
+      addOpenedPage({ title: t(currentRoute.meta.pageTitleI18n),
+        url: currentRoute.path });
+    }
   });
 
   /**

--- a/src/domain/workspace.repository.interface.ts
+++ b/src/domain/workspace.repository.interface.ts
@@ -22,7 +22,7 @@ export default interface WorkspaceRepositoryInterface {
   patchOpenedPageByUrl: (url: OpenedPage['url'], page: OpenedPage) => void;
 
   /**
-   * Delete all opened pages excluding Home page
+   * Delete all opened pages
    */
   deleteOpenedPages: () => void;
 

--- a/src/infrastructure/storage/openedPage.ts
+++ b/src/infrastructure/storage/openedPage.ts
@@ -63,13 +63,11 @@ export class OpenedPagesStore extends PersistantStore<OpenedPagesStoreData> {
   }
 
   /**
-   * Delete all opened pages excluding Home page
+   * Delete all opened pages
    */
   public deleteOpenedPages(): void {
     this.data.openedPages?.forEach((currentPage) => {
-      if (currentPage.url !== '/') {
-        this.deleteOpenedPageByUrl(currentPage.url);
-      }
+      this.deleteOpenedPageByUrl(currentPage.url);
     });
   }
 }

--- a/src/infrastructure/workspace.repository.ts
+++ b/src/infrastructure/workspace.repository.ts
@@ -39,7 +39,7 @@ export default class WorkspaceRepository extends Repository<OpenedPagesStore, Op
   }
 
   /**
-   * Delete all opened pages excluding Home page
+   * Delete all opened pages
    */
   public deleteOpenedPages(): void {
     this.store.deleteOpenedPages();

--- a/src/presentation/components/app-navbar/AppNavbar.vue
+++ b/src/presentation/components/app-navbar/AppNavbar.vue
@@ -47,7 +47,7 @@ const tabs = computed(() => currentOpenedPages.value.map((page): TabParams => {
   return {
     id: page.url,
     title: page.title,
-    closable: page.title !== 'Home',
+    closable: true,
     isActive: page.url === route.path,
   };
 }));


### PR DESCRIPTION
### Problem:

Home tab was integrated in tabbar for user to have ability to go to the home page (it is unclosable) when we did not have logo
Now we have logo to go to the home page, so home tab should not exist.

Solution:
As describe in issue https://github.com/codex-team/notes.web/issues/291, we will be removing home tab from the navbar and its special conditions.

Resolves https://github.com/codex-team/notes.web/issues/291