### PR TITLE
fix(marketplace): prevent layout shrink when right column is missing

### DIFF
--- a/@codexteam/ui/package.json
+++ b/@codexteam/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexteam/ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/@codexteam/ui/src/vue/layout/page-block/PageBlock.vue
+++ b/@codexteam/ui/src/vue/layout/page-block/PageBlock.vue
@@ -7,15 +7,13 @@
   >
     <!-- Left Sidebar -->
     <div
-      v-if="$slots.left"
       :class="$style['page-block__sidebar']"
     >
-      <slot name="left" />
+      <slot
+        v-if="$slots.left"
+        name="left"
+      />
     </div>
-    <div
-      :class="$style['page-block__sidebar']"
-      v-else
-    />
 
     <!-- Center Content -->
     <div
@@ -29,15 +27,13 @@
 
     <!-- Right Sidebar -->
     <div
-      v-if="$slots.right"
       :class="$style['page-block__sidebar']"
     >
-      <slot name="right" />
+      <slot
+        v-if="$slots.right"
+        name="right"
+      />
     </div>
-    <div
-      :class="$style['page-block__sidebar']"
-      v-else
-    />
   </div>
 </template>
 

--- a/@codexteam/ui/src/vue/layout/page-block/PageBlock.vue
+++ b/@codexteam/ui/src/vue/layout/page-block/PageBlock.vue
@@ -12,6 +12,10 @@
     >
       <slot name="left" />
     </div>
+    <div
+      :class="$style['page-block__sidebar']"
+      v-else
+    />
 
     <!-- Center Content -->
     <div
@@ -30,6 +34,10 @@
     >
       <slot name="right" />
     </div>
+    <div
+      :class="$style['page-block__sidebar']"
+      v-else
+    />
   </div>
 </template>
 


### PR DESCRIPTION
### Problem
On the NoteX Web if the right or left column is not rendered, the main layout shrinks unexpectedly.
<img width="1435" alt="Снимок экрана 2025-04-09 в 03 20 24" src="https://github.com/user-attachments/assets/7daa2c58-4dd5-49e1-97b8-ee9207383eea" />

### Solution
Added a placeholder sidebar element with fixed width when the right or left column slot is empty. This ensures the layout remains consistent even if no content is provided for the right or left column.
<img width="1438" alt="Снимок экрана 2025-04-09 в 03 21 00" src="https://github.com/user-attachments/assets/86c54d53-c573-4ff1-898a-012d63558639" />
