### PR TITLE
Fix: Display current note in BreadCrumbs component

### DIFF
--- a/src/presentation/components/breadcrumbs/BreadCrumbs.vue
+++ b/src/presentation/components/breadcrumbs/BreadCrumbs.vue
@@ -2,7 +2,7 @@
   <RouterLink
     v-for="(parent, index) in displayedParents"
     :key="index"
-    :to="{ path: parent.id ? `/note/${parent.id}` : '' }"
+    :to="`/note/${parent.id}`"
     class="breadcrumb"
   >
     {{ parent.content ? getTitle(parent.content) : '...' }}

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -5,7 +5,11 @@
     >
       <template #left>
         <BreadCrumbs
-          :note-parents="noteParents"
+          :note-parents="
+            note && noteId ?
+              [...noteParents, { id: noteId, content: note.content }] :
+              noteParents
+          "
         />
       </template>
       <template #right>


### PR DESCRIPTION
By this PR, in note's breadcrumbs also its title will be displayed

This resolves #323