### PR TITLE
Add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,6 +1,7 @@
 name: Publish CodeX UI to NPM
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Allow triggering the publish workflow manually from GitHub Actions UI. Useful for republishing after failed runs or testing pipeline changes.