### PR TITLE
fix: switching between notes may override note

### DIFF
--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -383,7 +383,7 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
 
     // Recursively update child notes
     if (hierarchy.childNotes) {
-      hierarchy.childNotes.forEach((child) => updateNoteHierarchyContent(child, title));
+      hierarchy.childNotes.forEach(child => updateNoteHierarchyContent(child, title));
     }
   }
 


### PR DESCRIPTION
Causes: watch() updated the tab by route.path.
When switching between notes quickly, load() could complete after switching to another note, but route.path would point to the new note.
State race during loading/saving:
Async load() and save() did not check that the currentId had not changed during the request. PATCH /note/:id updated the local state for a different note.