### PR TITLE
fix/add getter for editorComponent

### DIFF
--- a/@codexteam/ui/src/vue/components/editor/Editor.vue
+++ b/@codexteam/ui/src/vue/components/editor/Editor.vue
@@ -88,7 +88,9 @@ defineExpose({
   /**
    * Returns the editor holder
    */
-  element: editorComponent.value,
+  get element(): HTMLElement | null {
+    return editorComponent.value;
+  },
 });
 </script>
 


### PR DESCRIPTION
## Problem
When the user changes a note, the note screenshot isn't being taken and note covers aren't updating on the server. This happens because the editor holder was assigned before actual mounting and it references null.

## Solution
Add `element` getter for getting actual editorComponent.value.