### PR TITLE
Fix: ensure tools are configured before editor renders on note switch

### DIFF
--- a/@codexteam/ui/dev/pages/components/Editor.vue
+++ b/@codexteam/ui/dev/pages/components/Editor.vue
@@ -40,7 +40,7 @@
     placeholder="Write something or press / to select a tool"
     first-block-placeholder="Untitled"
     autofocus
-    :inlineToolbar="true"
+    :inline-toolbar="true"
   />
 </template>
 

--- a/@codexteam/ui/package.json
+++ b/@codexteam/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexteam/ui",
-  "version": "0.2.3",
+  "version": "0.2.5",
   "type": "module",
   "sideEffects": [
     "*.css",

--- a/@codexteam/ui/src/vue/components/editor/useEditor.ts
+++ b/@codexteam/ui/src/vue/components/editor/useEditor.ts
@@ -126,8 +126,7 @@ export function useEditor(editorConfig: MaybeRefOrGetter<EditorConfig>, options:
    * Destroy editor instance after unmount
    */
   onBeforeUnmount(() => {
-    editor?.destroy();
-    editor = undefined;
+    destroyEditor()
   });
 
   return {

--- a/@codexteam/ui/src/vue/components/editor/useEditor.ts
+++ b/@codexteam/ui/src/vue/components/editor/useEditor.ts
@@ -126,7 +126,7 @@ export function useEditor(editorConfig: MaybeRefOrGetter<EditorConfig>, options:
    * Destroy editor instance after unmount
    */
   onBeforeUnmount(() => {
-    destroyEditor()
+    destroyEditor();
   });
 
   return {

--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -131,8 +131,9 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
   /**
    * List of tools used in the note
    * Undefined when note is not loaded yet
+   * Empty array for drafts since they have no note tools
    */
-  const noteTools = ref<EditorTool[] | undefined>(undefined);
+  const noteTools = ref<EditorTool[] | undefined>(currentId.value === null ? [] : undefined);
 
   /**
    * Router instance used to replace the current route with note id
@@ -334,6 +335,7 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
    */
   function resetNote(): void {
     note.value = createDraft();
+    noteTools.value = [];
     canEdit.value = true;
     lastUpdateContent.value = null;
     noteHierarchy.value = null;

--- a/src/application/services/useNoteEditor.ts
+++ b/src/application/services/useNoteEditor.ts
@@ -18,12 +18,6 @@ interface UseNoteEditorOptions {
   noteContentResolver: () => NoteContent | undefined;
 
   /**
-   * Function to check if the note is a draft
-   * In draft we wont wait for note tools loading
-   */
-  isDraftResolver: () => boolean;
-
-  /**
    * Flag indicating that user can edit the note
    */
   canEdit: Ref<boolean>;
@@ -85,18 +79,21 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
 
   /**
    * Combine note and user tools
-   * Undefined when user or note is not loaded
+   * Returns undefined when note tools are not loaded yet to prevent
+   * premature editor rendering with an incomplete tools set
    */
   const noteAndUserTools = computed<EditorTool[] | undefined>(() => {
-    const noteTools = toValue(options.noteTools) || [];
-    const userTools = toValue(userEditorTools) ?? [];
+    const noteTools = toValue(options.noteTools);
 
     /**
-     * If tools are not loaded yet, return undefined
+     * If note tools are not loaded yet, return undefined to prevent
+     * premature editor rendering
      */
     if (noteTools === undefined) {
       return undefined;
     }
+
+    const userTools = toValue(userEditorTools) ?? [];
 
     /**
      * Return unique array of tools grouped by tool.name

--- a/src/application/services/useNoteEditor.ts
+++ b/src/application/services/useNoteEditor.ts
@@ -144,6 +144,9 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
       return;
     }
 
+    isEditorReady.value = false;
+    toolsUserConfigLoaded.value = false;
+
     await loadToolsScripts(tools);
   }, {
     immediate: true, // load tools if they are passed to the composable immediately

--- a/src/application/services/useNoteEditor.ts
+++ b/src/application/services/useNoteEditor.ts
@@ -77,6 +77,13 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
   const toolsUserConfigLoaded = ref<boolean>(false);
 
   /**
+   * Incremented on each new load request to discard stale async results.
+   * Prevents race conditions when rapid note switching causes multiple
+   * concurrent loadToolsScripts invocations.
+   */
+  let currentLoadId = 0;
+
+  /**
    * Combine note and user tools
    * Undefined when user or note is not loaded
    */
@@ -102,10 +109,12 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
   });
 
   /**
-   * Downloads passed tools scripts and toggles-on the isEditorReady flag
+   * Downloads passed tools scripts and returns the loaded config object.
+   * Does not mutate shared state — the caller is responsible for applying the result
    * @param toolsConfigs - tools to download
+   * @returns loaded tools config
    */
-  async function loadToolsScripts(toolsConfigs: EditorTool[]): Promise<void> {
+  async function loadToolsScripts(toolsConfigs: EditorTool[]): Promise<Record<string, { class: EditorjsConfigTool; inlineToolbar: boolean }>> {
     const loadedTools = await editorToolsService.getToolsLoaded(toolsConfigs);
 
     /**
@@ -114,7 +123,7 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
      */
     const loadedToolsWithoutParagraph = loadedTools.filter(tool => tool.tool.name !== 'paragraph');
 
-    toolsUserConfig = Object.fromEntries(
+    return Object.fromEntries(
       loadedToolsWithoutParagraph
         .map(toolClassAndInfo => [
           toolClassAndInfo.tool.name,
@@ -124,12 +133,6 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
           },
         ])
     );
-    toolsUserConfigLoaded.value = true;
-
-    /**
-     * Now all tools are loaded, we're ready to use the editor
-     */
-    isEditorReady.value = true;
   }
 
   /**
@@ -144,10 +147,28 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
       return;
     }
 
+    const loadId = ++currentLoadId;
+
     isEditorReady.value = false;
     toolsUserConfigLoaded.value = false;
 
-    await loadToolsScripts(tools);
+    const loadedConfig = await loadToolsScripts(tools);
+
+    /**
+     * If a newer load request has superseded this one — discard stale results
+     * to prevent overwriting state with tools from a previous note.
+     */
+    if (loadId !== currentLoadId) {
+      return;
+    }
+
+    toolsUserConfig = loadedConfig;
+    toolsUserConfigLoaded.value = true;
+
+    /**
+     * Now all tools are loaded, we're ready to use the editor
+     */
+    isEditorReady.value = true;
   }, {
     immediate: true, // load tools if they are passed to the composable immediately
   });

--- a/src/application/services/useNoteEditor.ts
+++ b/src/application/services/useNoteEditor.ts
@@ -88,8 +88,7 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
    * Undefined when user or note is not loaded
    */
   const noteAndUserTools = computed<EditorTool[] | undefined>(() => {
-    const isDraft = options.isDraftResolver();
-    const noteTools = isDraft ? [] : toValue(options.noteTools);
+    const noteTools = toValue(options.noteTools) || [];
     const userTools = toValue(userEditorTools) ?? [];
 
     /**

--- a/src/application/services/useNoteEditor.ts
+++ b/src/application/services/useNoteEditor.ts
@@ -164,11 +164,10 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
       }
 
       toolsUserConfig = loadedConfig;
+      toolsUserConfigLoaded.value = true;
     } catch (error) {
       throw new Error(`Failed to load tools scripts: ${error instanceof Error ? error.message : String(error)}`);
     } finally {
-      toolsUserConfigLoaded.value = true;
-
       /**
        * Display the editor regardless of tool loading failures, as it can be displayed with default tools
        */

--- a/src/application/services/useNoteEditor.ts
+++ b/src/application/services/useNoteEditor.ts
@@ -152,23 +152,28 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
     isEditorReady.value = false;
     toolsUserConfigLoaded.value = false;
 
-    const loadedConfig = await loadToolsScripts(tools);
+    try {
+      const loadedConfig = await loadToolsScripts(tools);
 
-    /**
-     * If a newer load request has superseded this one — discard stale results
-     * to prevent overwriting state with tools from a previous note.
-     */
-    if (loadId !== currentLoadId) {
-      return;
+      /**
+       * If a newer load request has superseded this one — discard stale results
+       * to prevent overwriting state with tools from a previous note.
+       */
+      if (loadId !== currentLoadId) {
+        return;
+      }
+
+      toolsUserConfig = loadedConfig;
+    } catch (error) {
+      throw new Error(`Failed to load tools scripts: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      toolsUserConfigLoaded.value = true;
+
+      /**
+       * Show editor even if tools are not loaded yet, since we can still show the editor with default tools
+       */
+      isEditorReady.value = true;
     }
-
-    toolsUserConfig = loadedConfig;
-    toolsUserConfigLoaded.value = true;
-
-    /**
-     * Now all tools are loaded, we're ready to use the editor
-     */
-    isEditorReady.value = true;
   }, {
     immediate: true, // load tools if they are passed to the composable immediately
   });

--- a/src/application/services/useNoteEditor.ts
+++ b/src/application/services/useNoteEditor.ts
@@ -170,7 +170,7 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
       toolsUserConfigLoaded.value = true;
 
       /**
-       * Show editor even if tools are not loaded yet, since we can still show the editor with default tools
+       * Display the editor regardless of tool loading failures, as it can be displayed with default tools
        */
       isEditorReady.value = true;
     }

--- a/src/application/services/useNoteEditor.ts
+++ b/src/application/services/useNoteEditor.ts
@@ -169,9 +169,12 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
       throw new Error(`Failed to load tools scripts: ${error instanceof Error ? error.message : String(error)}`);
     } finally {
       /**
-       * Display the editor regardless of tool loading failures, as it can be displayed with default tools
+       * Display the editor regardless of tool loading failures, as it can be displayed with default tools.
+       * Only the latest load request may mark the editor as ready
        */
-      isEditorReady.value = true;
+      if (loadId === currentLoadId) {
+        isEditorReady.value = true;
+      }
     }
   }, {
     immediate: true, // load tools if they are passed to the composable immediately

--- a/src/application/services/useNoteEditor.ts
+++ b/src/application/services/useNoteEditor.ts
@@ -3,7 +3,7 @@ import { useAppState } from './useAppState';
 import type EditorTool from '@/domain/entities/EditorTool';
 import { type NoteContent } from '@/domain/entities/Note';
 import { editorToolsService } from '@/domain';
-import type { EditorjsConfigTool } from '@/domain/entities/EditorTool';
+import type { EditorjsToolsConfig } from '@/domain/entities/EditorTool';
 import { useI18n } from 'vue-i18n';
 
 interface UseNoteEditorOptions {
@@ -68,7 +68,7 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
    * Loaded tools classes by grouped by tool.name
    * Undefined when tools are not loaded yet
    */
-  let toolsUserConfig: Record<string, { class: EditorjsConfigTool; inlineToolbar: boolean }> | undefined = undefined;
+  let toolsUserConfig: EditorjsToolsConfig | undefined = undefined;
 
   /**
    * We can't make toolsUserConfig reactive since it contains excecutable js-classes, Vue can't handle that.
@@ -114,7 +114,7 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
    * @param toolsConfigs - tools to download
    * @returns loaded tools config
    */
-  async function loadToolsScripts(toolsConfigs: EditorTool[]): Promise<Record<string, { class: EditorjsConfigTool; inlineToolbar: boolean }>> {
+  async function loadToolsScripts(toolsConfigs: EditorTool[]): Promise<EditorjsToolsConfig> {
     const loadedTools = await editorToolsService.getToolsLoaded(toolsConfigs);
 
     /**

--- a/src/application/services/useNoteEditor.ts
+++ b/src/application/services/useNoteEditor.ts
@@ -55,8 +55,10 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
 
   /**
    * Reactive object with editor tools installed by user
+   * User is undefined while authorization is in progress,
+   * null when user is not authenticated, User instance otherwise
    */
-  const { userEditorTools } = useAppState();
+  const { userEditorTools, user } = useAppState();
 
   /**
    * Loaded tools classes by grouped by tool.name
@@ -79,11 +81,13 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
 
   /**
    * Combine note and user tools
-   * Returns undefined when note tools are not loaded yet to prevent
+   * Returns undefined when tools are not loaded yet to prevent
    * premature editor rendering with an incomplete tools set
    */
   const noteAndUserTools = computed<EditorTool[] | undefined>(() => {
     const noteTools = toValue(options.noteTools);
+    const userTools = toValue(userEditorTools);
+    const currentUser = toValue(user);
 
     /**
      * If note tools are not loaded yet, return undefined to prevent
@@ -93,12 +97,18 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
       return undefined;
     }
 
-    const userTools = toValue(userEditorTools) ?? [];
+    /**
+     * If user is authenticated but their tools are not loaded yet, wait for them to load
+     * When user is not authenticated userTools stays undefined
+     */
+    if (currentUser !== null && userTools === undefined) {
+      return undefined;
+    }
 
     /**
      * Return unique array of tools grouped by tool.name
      */
-    const combinedTools = [...noteTools, ...userTools];
+    const combinedTools = [...noteTools, ...(userTools ?? [])];
     const uniqueTools = new Map(combinedTools.map(tool => [tool.name, tool]));
 
     return Array.from(uniqueTools.values());

--- a/src/domain/entities/EditorTool.ts
+++ b/src/domain/entities/EditorTool.ts
@@ -79,6 +79,11 @@ export type NewToolData = Omit<EditorTool, 'userId' | 'id' | 'cover'> & {
 export type EditorjsConfigTool = ToolSettings | ToolConstructable;
 
 /**
+ * Editor.js tools config — map of tool name to its class and inline toolbar flag
+ */
+export type EditorjsToolsConfig = Record<string, { class: EditorjsConfigTool; inlineToolbar: boolean }>;
+
+/**
  * Editor tool info alogn with its plugin's class ready to use
  */
 export interface EditorToolLoaded {

--- a/src/presentation/pages/HistoryVersion.vue
+++ b/src/presentation/pages/HistoryVersion.vue
@@ -84,7 +84,6 @@ const canEdit = ref(false);
 
 const { isEditorReady, editorConfig } = useNoteEditor({
   noteTools: historyTools,
-  isDraftResolver: () => false,
   noteContentResolver: () => historyContent.value,
   canEdit,
 });

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -127,7 +127,6 @@ const { updateCover } = useNoteSettings();
 
 const { isEditorReady, editorConfig } = useNoteEditor({
   noteTools,
-  isDraftResolver: () => noteId.value === null,
   noteContentResolver: () => note.value?.content,
   canEdit,
 });


### PR DESCRIPTION
# Problem:
<img width="680" height="202" alt="image" src="https://github.com/user-attachments/assets/b2537533-d913-4bb4-b3e6-302ec8820b79" />
Occasionally, when switching between notes, some editor.js blocks may not be displayed correctly.

# Root Cause:
<img width="500" height="51" alt="image" src="https://github.com/user-attachments/assets/9c9564f2-27b8-4fd7-b1b3-fbf2d97ae47e" />
*toolsUserConfigLoaded and isEditorReady already true when the function is just called*

This issue occurs because the toolsUserConfigLoaded and isEditorReady flags are not properly reset. As a result, the editor may render before the tools are fully configured, causing certain blocks to fail to display.

# What done:
- Added logic to reset toolsUserConfigLoaded and isEditorReady before calling loadToolsScripts, ensuring that the editor waits for the tools to be properly configured before rendering.
- Destroy the editor reliably on unmount to prevent bug (screenshot bellow) when the previous editor instance wasn't cleaned up.
<img width="519" height="626" alt="image" src="https://github.com/user-attachments/assets/a73bf714-fe68-4621-8fa0-634a885e7aa4" />

- Added a load counter to discard stale async results and prevent race conditions during rapid note switching.
