### PR TITLE
Refactor: optimize notes covers rendering

### DIFF
--- a/@codexteam/ui/package.json
+++ b/@codexteam/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexteam/ui",
-  "version": "0.2.3",
+  "version": "0.2.5",
   "type": "module",
   "sideEffects": [
     "*.css",

--- a/@codexteam/ui/src/vue/components/card/Card.vue
+++ b/@codexteam/ui/src/vue/components/card/Card.vue
@@ -6,8 +6,13 @@
     ]"
   >
     <div
-      :class="$style['card__cover']"
-      :style="`background-image: url(${src})`"
+      :class="[
+        $style['card__cover'],
+        {
+          [$style['card__cover--skeleton']]: isCoverLoading,
+        },
+      ]"
+      :style="src ? `background-image: url(${src})` : undefined"
     />
 
     <div :class="$style['card__body']">
@@ -55,12 +60,19 @@ withDefaults(
      * Cover image source
      */
     src?: string;
+
+    /**
+     * Loading state.
+     * When true shows skeleton shimmer on cover
+     */
+    isCoverLoading?: boolean;
   }>(),
   {
     title: '',
     subtitle: '',
     orientation: 'vertical',
     src: '',
+    isCoverLoading: false,
   }
 );
 </script>
@@ -113,10 +125,31 @@ withDefaults(
     border-radius: var(--radius-m);
     background-color: var(--base--bg-primary);
     background-size: cover;
+
+    &--skeleton {
+      background-color: color-mix(in srgb, var(--base--text-secondary) 10%, transparent);
+      background-image: linear-gradient(
+        to left,
+        color-mix(in srgb, var(--base--text-secondary) 30%, transparent) 0%,
+        color-mix(in srgb, var(--base--text-secondary) 10%, transparent) 50%,
+        color-mix(in srgb, var(--base--text-secondary) 30%, transparent) 100%
+      );
+      background-size: 200% 100%;
+      animation: card-skeleton-animation 3s infinite linear;
+    }
   }
 
   &__title {
     color: var(--base--text);
+  }
+}
+
+@keyframes card-skeleton-animation {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
   }
 }
 </style>

--- a/src/application/services/useNoteList.ts
+++ b/src/application/services/useNoteList.ts
@@ -34,6 +34,11 @@ interface UseNoteListComposableState {
    * Loading state
    */
   isLoading: Ref<boolean>;
+
+  /**
+   * Set of note IDs whose cover downloads are currently in-flight
+   */
+  coversLoading: Ref<Set<string>>;
 }
 
 /**
@@ -86,7 +91,7 @@ export default function (onlyCreatedByUser = false): UseNoteListComposableState 
    * Prevents duplicate requests when loadMoreNotes() fires again before
    * covers for the previous page have finished loading.
    */
-  const coversLoading = new Set<string>();
+  const coversLoading = ref(new Set<string>());
 
   /**
    * Load cover images for all notes in the list in the background
@@ -118,11 +123,11 @@ export default function (onlyCreatedByUser = false): UseNoteListComposableState 
       /**
        * If this note's cover is already being fetched, skip it
        */
-      if (coversLoading.has(item.id)) {
+      if (coversLoading.value.has(item.id)) {
         return;
       }
 
-      coversLoading.add(item.id);
+      coversLoading.value = new Set(coversLoading.value).add(item.id);
 
       try {
         const url = await noteListService.loadCover(item.id, item.cover);
@@ -142,7 +147,10 @@ export default function (onlyCreatedByUser = false): UseNoteListComposableState 
           };
         }
       } finally {
-        coversLoading.delete(item.id);
+        const next = new Set(coversLoading.value);
+
+        next.delete(item.id);
+        coversLoading.value = next;
       }
     }));
   };
@@ -205,5 +213,6 @@ export default function (onlyCreatedByUser = false): UseNoteListComposableState 
     load,
     loadMoreNotes,
     isLoading,
+    coversLoading,
   };
 }

--- a/src/application/services/useNoteList.ts
+++ b/src/application/services/useNoteList.ts
@@ -111,11 +111,16 @@ export default function (onlyCreatedByUser = false): UseNoteListComposableState 
       const url = await noteListService.loadCover(item.id, item.cover);
 
       if (url !== null) {
+        const currentItem = list.items[index];
+
+        if (currentItem?.id !== item.id) {
+          return;
+        }
         /**
          * Update the specific note's cover reactively so the card renders the image
          */
         list.items[index] = {
-          ...item,
+          ...currentItem,
           cover: url,
         };
       }

--- a/src/application/services/useNoteList.ts
+++ b/src/application/services/useNoteList.ts
@@ -74,12 +74,11 @@ export default function (onlyCreatedByUser = false): UseNoteListComposableState 
    */
   const load = async (page: number): Promise<NoteList> => {
     isLoading.value = true;
-
-    const list = await noteListService.getNoteList(page, onlyCreatedByUser);
-
-    isLoading.value = false;
-
-    return list;
+    try {
+      return await noteListService.getNoteList(page, onlyCreatedByUser);
+    } finally {
+      isLoading.value = false;
+    }
   };
 
   /**

--- a/src/application/services/useNoteList.ts
+++ b/src/application/services/useNoteList.ts
@@ -69,7 +69,7 @@ export default function (onlyCreatedByUser = false): UseNoteListComposableState 
   const isLoading = ref(false);
 
   /**
-   * Get note list
+   * Get note list (metadata only, covers are not downloaded)
    * @param page - number of pages
    */
   const load = async (page: number): Promise<NoteList> => {
@@ -80,6 +80,47 @@ export default function (onlyCreatedByUser = false): UseNoteListComposableState 
     isLoading.value = false;
 
     return list;
+  };
+
+  /**
+   * Load cover images for all notes in the list in the background
+   * Updates each note's cover reactively as it arrives
+   */
+  const loadCovers = async (): Promise<void> => {
+    if (isEmpty(noteList.value)) {
+      return;
+    }
+
+    const list = noteList.value;
+    const items = list.items;
+
+    await Promise.all(items.map(async (item, index) => {
+      /**
+       * If cover is null, the note has no cover image
+       */
+      if (item.cover === null) {
+        return;
+      }
+
+      /**
+       * If cover is already a blob URL, it was already loaded
+       */
+      if (item.cover.startsWith('blob:')) {
+        return;
+      }
+
+      const url = await noteListService.loadCover(item.id, item.cover);
+
+      if (url !== null) {
+        /**
+         * Update the specific note's cover reactively so the card renders the image
+         */
+        list.items[index] = {
+          ...item,
+          cover: url,
+        };
+      }
+    }));
   };
 
   /**
@@ -102,6 +143,12 @@ export default function (onlyCreatedByUser = false): UseNoteListComposableState 
     } else {
       noteList.value = loadedNotes;
     }
+
+    /**
+     * Kick off cover downloads in the background
+     * List is already rendered, covers will appear one by one as they load
+     */
+    loadCovers().catch(console.error);
   };
 
   /**

--- a/src/application/services/useNoteList.ts
+++ b/src/application/services/useNoteList.ts
@@ -82,6 +82,13 @@ export default function (onlyCreatedByUser = false): UseNoteListComposableState 
   };
 
   /**
+   * Set of note IDs whose cover downloads are currently in-flight
+   * Prevents duplicate requests when loadMoreNotes() fires again before
+   * covers for the previous page have finished loading.
+   */
+  const coversLoading = new Set<string>();
+
+  /**
    * Load cover images for all notes in the list in the background
    * Updates each note's cover reactively as it arrives
    */
@@ -108,21 +115,34 @@ export default function (onlyCreatedByUser = false): UseNoteListComposableState 
         return;
       }
 
-      const url = await noteListService.loadCover(item.id, item.cover);
+      /**
+       * If this note's cover is already being fetched, skip it
+       */
+      if (coversLoading.has(item.id)) {
+        return;
+      }
 
-      if (url !== null) {
-        const currentItem = list.items[index];
+      coversLoading.add(item.id);
 
-        if (currentItem?.id !== item.id) {
-          return;
+      try {
+        const url = await noteListService.loadCover(item.id, item.cover);
+
+        if (url !== null) {
+          const currentItem = list.items[index];
+
+          if (currentItem?.id !== item.id) {
+            return;
+          }
+          /**
+           * Update the specific note's cover reactively so the card renders the image
+           */
+          list.items[index] = {
+            ...currentItem,
+            cover: url,
+          };
         }
-        /**
-         * Update the specific note's cover reactively so the card renders the image
-         */
-        list.items[index] = {
-          ...currentItem,
-          cover: url,
-        };
+      } finally {
+        coversLoading.delete(item.id);
       }
     }));
   };

--- a/src/domain/noteList.service.ts
+++ b/src/domain/noteList.service.ts
@@ -20,49 +20,31 @@ export default class NoteListService {
   }
 
   /**
-   * Returns note list
-   * @todo - move loading images data logic to separate service for optimization
+   * Returns note list with metadata only (covers are not downloaded)
    * @param page - number of current pages
    * @param onlyCreatedByUser - if true, returns notes created by the user
    * @returns list of notes
    */
   public async getNoteList(page: number, onlyCreatedByUser = false): Promise<NoteList> {
-    const noteList = await this.repository.getNoteList(page, onlyCreatedByUser);
+    return await this.repository.getNoteList(page, onlyCreatedByUser);
+  }
 
-    /**
-     * Load cover image for a single note in parallel
-     * @param note - Note entity
-     * @returns Note with cover blob URL (or null cover on error)
-     */
-    const loadCover = async (note: NoteList['items'][number]): Promise<NoteList['items'][number]> => {
-      if (note.cover === null) {
-        return note;
-      }
+  /**
+   * Load cover image for a single note and return its blob URL
+   * @param noteId - Note identifier
+   * @param coverKey - Cover file key on server
+   * @returns Blob URL for the cover image, or null on error
+   */
+  public async loadCover(noteId: string, coverKey: string): Promise<string | null> {
+    try {
+      const imageData = await this.noteAttachmentRepository.load(noteId, coverKey);
 
-      try {
-        const imageData = await this.noteAttachmentRepository.load(note.id, note.cover);
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      return URL.createObjectURL(imageData);
+    } catch {
+      console.log('Error while loading cover for note ', noteId);
 
-        // eslint-disable-next-line n/no-unsupported-features/node-builtins
-        const objUrl = URL.createObjectURL(imageData);
-
-        return {
-          ...note,
-          cover: objUrl,
-        };
-      } catch {
-        console.log('Error while loading cover for note ', note.id);
-
-        return note;
-      }
-    };
-
-    /**
-     * Load all cover images in parallel
-     */
-    const parsedNoteList: NoteList = {
-      items: await Promise.all(noteList.items.map(loadCover)),
-    };
-
-    return parsedNoteList;
+      return null;
+    }
   }
 }

--- a/src/domain/noteList.service.ts
+++ b/src/domain/noteList.service.ts
@@ -30,43 +30,38 @@ export default class NoteListService {
     const noteList = await this.repository.getNoteList(page, onlyCreatedByUser);
 
     /**
-     * Note list with valid image urls in cover
+     * Load cover image for a single note in parallel
+     * @param note - Note entity
+     * @returns Note with cover blob URL (or null cover on error)
      */
-    const parsedNoteList: NoteList = {
-      items: [],
-    };
-
-    for (const note of noteList.items) {
-      /**
-       * If note has no cover, we have no need to load it
-       */
+    const loadCover = async (note: NoteList['items'][number]): Promise<NoteList['items'][number]> => {
       if (note.cover === null) {
-        parsedNoteList.items.push(note);
-        continue;
+        return note;
       }
-
-      /**
-       * Cover object url for passing to the element
-       */
-      let objUrl: string | null = null;
 
       try {
         const imageData = await this.noteAttachmentRepository.load(note.id, note.cover);
 
-        /**
-         * Make url from blob data
-         */
         // eslint-disable-next-line n/no-unsupported-features/node-builtins
-        objUrl = URL.createObjectURL(imageData);
+        const objUrl = URL.createObjectURL(imageData);
+
+        return {
+          ...note,
+          cover: objUrl,
+        };
       } catch {
         console.log('Error while loading cover for note ', note.id);
-      }
 
-      parsedNoteList.items.push({
-        ...note,
-        cover: objUrl,
-      });
-    }
+        return note;
+      }
+    };
+
+    /**
+     * Load all cover images in parallel
+     */
+    const parsedNoteList: NoteList = {
+      items: await Promise.all(noteList.items.map(loadCover)),
+    };
 
     return parsedNoteList;
   }

--- a/src/presentation/components/note-list/NoteList.vue
+++ b/src/presentation/components/note-list/NoteList.vue
@@ -16,6 +16,7 @@
           :title="getTitle(note.content)"
           :subtitle="getSubtitle(note)"
           :src="note.cover?.startsWith('blob:') ? note.cover : undefined"
+          :is-cover-loading="note.cover !== null && coversLoading.has(note.id)"
           orientation="vertical"
         />
       </RouterLink>
@@ -62,6 +63,7 @@ const {
   loadMoreNotes,
   hasMoreNotes,
   isLoading,
+  coversLoading,
 } = useNoteList(props.onlyCreatedByUser);
 const { t } = useI18n();
 

--- a/src/presentation/components/note-list/NoteList.vue
+++ b/src/presentation/components/note-list/NoteList.vue
@@ -15,7 +15,7 @@
         <Card
           :title="getTitle(note.content)"
           :subtitle="getSubtitle(note)"
-          :src="note.cover || undefined"
+          :src="note.cover?.startsWith('blob:') ? note.cover : undefined"
           orientation="vertical"
         />
       </RouterLink>


### PR DESCRIPTION
## Refactor: optimize notes covers rendering

### Problem
The homepage currently suffers from poor loading performance. The note list is not displayed until all cover images have finished downloading, causing significant delays — especially on slower connections.

### Solution
- **Parallelized cover requests** — switched to asynchronous requests for downloading covers, allowing multiple connections to be established simultaneously for faster overall load time.
- **Decoupled cover loading from metadata fetching** — note metadata now loads first, while covers are fetched independently in the background.
- **Reactive cover rendering** — covers appear on cards progressively as soon as each individual image finishes downloading, rather than waiting for the entire batch to complete.

### Preview
<img width="902" height="759" alt="Peek 2026-07-08 13-125" src="https://github.com/user-attachments/assets/d4eb8410-f247-4880-8d0a-42d652810f5d" />

### Implementation Details

**`noteList.service.ts`**
- `getNoteList()` now returns metadata only (cover downloads are excluded)
- Added new `loadCover()` method for per-note asynchronous cover fetching

**`useNoteList.ts`**
- Introduced `loadCovers()` which downloads all covers in parallel using `Promise.all()` and updates each note reactively upon completion
- `loadNextPage()` triggers `loadCovers()` in the background after the list is rendered, ensuring a smooth user experience

### Performance Improvements
Tested on Linux in Firefox and Chrome


Home page loading (30 notes with covers):
| Browser | Before | After |
|---------|--------|-------|
| Firefox | ~20s   | ~5s   |
| Chrome  | ~12s   | ~4s   |