### PR TITLE
feat: user cannot delete himself from team

### DIFF
--- a/src/presentation/components/team/MoreActions.vue
+++ b/src/presentation/components/team/MoreActions.vue
@@ -18,9 +18,9 @@ import { type TeamMember } from '@/domain/entities/Team';
 import { useI18n } from 'vue-i18n';
 import { NoteId } from '@/domain/entities/Note';
 import useNoteSettings from '@/application/services/useNoteSettings';
+import { useAppState } from '@/application/services/useAppState';
 
 const { removeMemberByUserId } = useNoteSettings();
-
 const props = defineProps<{
   /**
    * Team member data
@@ -32,28 +32,31 @@ const props = defineProps<{
   noteId: NoteId;
 }>();
 
+const { user } = useAppState();
 const { t } = useI18n();
 const { showPopover, hide } = usePopover();
 const { confirm } = useConfirm();
 
 const triggerButton = ref<HTMLButtonElement>();
 
-const menuItems: ContextMenuItem[] = [
-  {
+const menuItems: ContextMenuItem[] = [];
+
+if (props.teamMember.user.email !== user.value?.email) {
+  menuItems.push({
     title: t('noteSettings.team.contextMenu.remove'),
     onActivate: async () => {
       hide();
       await handleRemove(props.teamMember);
     },
-  },
-];
+  });
+}
 
 const emit = defineEmits<{
   teamMemberRemoved: [userId: TeamMember['user']['id']];
 }>();
 
 const handleButtonClick = (): void => {
-  if (triggerButton.value) {
+  if (triggerButton.value && menuItems.length > 0) {
     showPopover({
       targetEl: triggerButton.value,
       with: {

--- a/src/presentation/components/team/MoreActions.vue
+++ b/src/presentation/components/team/MoreActions.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import { Icon, ContextMenu, usePopover, useConfirm, type ContextMenuItem } from '@codexteam/ui/vue';
 import { type TeamMember } from '@/domain/entities/Team';
 import { useI18n } from 'vue-i18n';
@@ -39,30 +39,34 @@ const { confirm } = useConfirm();
 
 const triggerButton = ref<HTMLButtonElement>();
 
-const menuItems: ContextMenuItem[] = [];
+const menuItems = computed<ContextMenuItem[]>(() => {
+  const items: ContextMenuItem[] = [];
 
-if (props.teamMember.user.email !== user.value?.email) {
-  menuItems.push({
-    title: t('noteSettings.team.contextMenu.remove'),
-    onActivate: async () => {
-      hide();
-      await handleRemove(props.teamMember);
-    },
-  });
-}
+  if (props.teamMember.user.email !== user.value?.email) {
+    items.push({
+      title: t('noteSettings.team.contextMenu.remove'),
+      onActivate: async () => {
+        hide();
+        await handleRemove(props.teamMember);
+      },
+    });
+  }
+
+  return items;
+});
 
 const emit = defineEmits<{
   teamMemberRemoved: [userId: TeamMember['user']['id']];
 }>();
 
 const handleButtonClick = (): void => {
-  if (triggerButton.value && menuItems.length > 0) {
+  if (triggerButton.value && menuItems.value.length > 0) {
     showPopover({
       targetEl: triggerButton.value,
       with: {
         component: ContextMenu,
         props: {
-          items: menuItems,
+          items: menuItems.value,
         },
       },
       align: {

--- a/src/presentation/components/team/MoreActions.vue
+++ b/src/presentation/components/team/MoreActions.vue
@@ -42,7 +42,7 @@ const triggerButton = ref<HTMLButtonElement>();
 const menuItems = computed<ContextMenuItem[]>(() => {
   const items: ContextMenuItem[] = [];
 
-  if (props.teamMember.user.email !== user.value?.email) {
+  if (props.teamMember.user.id !== user.value?.id) {
     items.push({
       title: t('noteSettings.team.contextMenu.remove'),
       onActivate: async () => {


### PR DESCRIPTION
Prevent a user from removing themselves from the note's team member list.

## Changes

- The "Remove" context menu item is now only shown for team members whose email does not match the current user's email

- The popover button is only shown when there is at least one menu item to display
