### PR TITLE
Fix: overwrite note content on switching

### DIFF
--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -96,6 +96,13 @@ interface UseNoteComposableState {
    * Note hierarchy
    */
   noteHierarchy: Ref<NoteHierarchy | null>;
+
+  /**
+   * Returns the id of the note created by the most recent save() on a new note
+   * Used to distinguish "same note just got an id after save" from
+   * "switched to a different existing note"
+   */
+  getLastCreatedNoteId: () => NoteId | null;
 }
 
 interface UseNoteComposableOptions {
@@ -183,6 +190,12 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
    * null by default
    */
   const noteHierarchy = ref<NoteHierarchy | null>(null);
+
+  /**
+   * Id of the note created by the most recent save() on a new note
+   * Used to skip the reload after save so the editor doesn't get recreated
+   */
+  let lastCreatedNoteId: NoteId | null = null;
 
   /**
    * get note hierarchy
@@ -273,6 +286,19 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
        * @todo try-catch domain errors
        */
       const noteCreated = await noteService.createNote(content, specifiedNoteTools, parentId);
+
+      /**
+       * Remember the created note id so the editor can avoid
+       * recreating itself when the route switches from "new note" to the newly created note id
+       */
+      lastCreatedNoteId = noteCreated.id;
+
+      /**
+       * Store the saved content so the navbar title reflects it
+       */
+      if (currentId.value === currentNoteId) {
+        lastUpdateContent.value = content;
+      }
 
       /**
        * Replace the current route with note id
@@ -389,6 +415,14 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
       return;
     }
 
+    /**
+     * If the note was just created via save() and is still a draft (no id yet),
+     * skip the reload to avoid recreating the editor with the same content.
+     */
+    if (newId === lastCreatedNoteId && note.value !== null && !('id' in note.value)) {
+      return;
+    }
+
     void load(newId);
   });
 
@@ -416,5 +450,6 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
     noteParents,
     parentNote,
     noteHierarchy,
+    getLastCreatedNoteId: () => lastCreatedNoteId,
   };
 }

--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -202,6 +202,7 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
       const response = await noteService.getNoteById(id);
 
       note.value = response.note;
+      lastUpdateContent.value = response.note.content;
       canEdit.value = response.accessRights.canEdit;
       noteTools.value = response.tools;
       parentNote.value = response.parentNote;
@@ -290,9 +291,12 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
     }
 
     /**
-     * Store just saved content in memory
+     * Store just saved content in memory only if the current note hasn't changed
+     * This prevents race conditions when switching between notes quickly
      */
-    lastUpdateContent.value = content;
+    if (currentId.value === currentNoteId) {
+      lastUpdateContent.value = content;
+    }
 
     isNoteSaving.value = false;
   }

--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -55,7 +55,7 @@ interface UseNoteComposableState {
   /**
    * Creates/updates the note
    */
-  save: (content: NoteContent, parentId: NoteId | undefined) => Promise<void>;
+  save: (content: NoteContent, parentId: NoteId | undefined, currentNoteId: NoteId | null) => Promise<void>;
 
   /**
    * Returns list of tools used in note
@@ -244,8 +244,9 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
    * Saves the note
    * @param content - Note content (Editor.js data)
    * @param parentId - Id of the parent note. If null, then it's a root note
+   * @param currentNoteId - Id of the current note
    */
-  async function save(content: NoteContent, parentId: NoteId | undefined): Promise<void> {
+  async function save(content: NoteContent, parentId: NoteId | undefined, currentNoteId: NoteId | null): Promise<void> {
     if (note.value === null) {
       throw new Error('Note is not loaded yet');
     }
@@ -257,7 +258,7 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
 
     isNoteSaving.value = true;
 
-    if (currentId.value === null) {
+    if (currentNoteId === null) {
       /**
        * @todo try-catch domain errors
        */
@@ -285,7 +286,7 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
        */
       void getNoteHierarchy(noteCreated.id);
     } else {
-      await noteService.updateNoteContentAndTools(currentId.value, content, specifiedNoteTools);
+      await noteService.updateNoteContentAndTools(currentNoteId as NoteId, content, specifiedNoteTools);
     }
 
     /**

--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -142,6 +142,13 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
   const route = useRoute();
 
   /**
+   * Incremented on each new load request to discard stale async results
+   * Prevents race conditions when rapidly switching between notes causes
+   * multiple concurrent load() invocations to resolve out of order
+   */
+  let currentLoadId = 0;
+
+  /**
    * Note Title identifier
    */
   const noteTitle = computed(() => {
@@ -192,8 +199,18 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
    * @param id - Note identifier got from composable argument
    */
   async function load(id: NoteId): Promise<void> {
+    const loadId = ++currentLoadId;
+
     try {
       const response = await noteService.getNoteById(id);
+
+      /**
+       * If a newer load request has superseded this one — discard stale results
+       * to prevent mismatched content/tools state when switching notes quickly
+       */
+      if (loadId !== currentLoadId) {
+        return;
+      }
 
       note.value = response.note;
       lastUpdateContent.value = response.note.content;

--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -287,7 +287,7 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
        */
       void getNoteHierarchy(noteCreated.id);
     } else {
-      await noteService.updateNoteContentAndTools(currentNoteId as NoteId, content, specifiedNoteTools);
+      await noteService.updateNoteContentAndTools(currentNoteId, content, specifiedNoteTools);
     }
 
     /**

--- a/src/application/services/useNote.ts
+++ b/src/application/services/useNote.ts
@@ -142,12 +142,6 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
   const route = useRoute();
 
   /**
-   * Is there any note currently saving
-   * Used to prevent re-load note after draft is saved
-   */
-  const isNoteSaving = ref<boolean>(false);
-
-  /**
    * Note Title identifier
    */
   const noteTitle = computed(() => {
@@ -255,8 +249,6 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
      */
     const specifiedNoteTools = resolveToolsByContent(content);
 
-    isNoteSaving.value = true;
-
     if (currentId.value === null) {
       /**
        * @todo try-catch domain errors
@@ -292,8 +284,6 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
      * Store just saved content in memory
      */
     lastUpdateContent.value = content;
-
-    isNoteSaving.value = false;
   }
 
   /**
@@ -366,7 +356,7 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
     }
   }
 
-  watch(currentId, (newId, prevId) => {
+  watch(currentId, (newId, _prevId) => {
     /**
      * One note is open, user clicks on "+" to create another new note
      * Clear existing note
@@ -374,16 +364,6 @@ export default function (options: UseNoteComposableOptions): UseNoteComposableSt
     if (newId === null) {
       resetNote();
 
-      return;
-    }
-
-    const isDraftSaving = prevId === null && isNoteSaving.value;
-
-    /**
-     * Case for newly created note,
-     * we don't need to re-load it
-     */
-    if (isDraftSaving) {
       return;
     }
 

--- a/src/application/services/useNoteEditor.ts
+++ b/src/application/services/useNoteEditor.ts
@@ -34,6 +34,13 @@ interface UseNoteEditorOptions {
    * Flag indicating that user can edit the note
    */
   canEdit: Ref<boolean>;
+
+  /**
+   * Returns the id of the note created by the most recent save() on a new note
+   * Used to distinguish "same note just got an id after save" from
+   * "switched to a different existing note"
+   */
+  getLastCreatedNoteId?: () => NoteId | null;
 }
 
 interface UseNoteEditorComposableState {
@@ -91,13 +98,22 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
   let currentLoadId = 0;
 
   /**
-   * Reset editor state when the note changes
-   * Prevents showing the editor with stale tools or content
-   * from a previously opened note
+   * Reset the editor when the note changes.
+
+   * Exception — new note save: the route switches from null to createdId
+   * for the same note, so the editor must NOT be recreated
+   * (avoids blinking and losing the cursor).
    */
   watch(
     () => toValue(options.noteId),
-    () => {
+    (newId, oldId) => {
+      /**
+       * Same note just got an id after save — keep the editor as-is
+       */
+      if (oldId === null && newId !== null && options.getLastCreatedNoteId !== undefined && newId === options.getLastCreatedNoteId()) {
+        return;
+      }
+
       isEditorReady.value = false;
     },
     { immediate: true }

--- a/src/application/services/useNoteEditor.ts
+++ b/src/application/services/useNoteEditor.ts
@@ -148,7 +148,6 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
 
     const loadId = ++currentLoadId;
 
-    isEditorReady.value = false;
     toolsUserConfigLoaded.value = false;
 
     try {

--- a/src/application/services/useNoteEditor.ts
+++ b/src/application/services/useNoteEditor.ts
@@ -1,12 +1,19 @@
+import type { MaybeRefOrGetter } from 'vue';
 import { type Ref, computed, ref, toValue, watch } from 'vue';
 import { useAppState } from './useAppState';
 import type EditorTool from '@/domain/entities/EditorTool';
+import type { NoteId } from '@/domain/entities/Note';
 import { type NoteContent } from '@/domain/entities/Note';
 import { editorToolsService } from '@/domain';
 import type { EditorjsToolsConfig } from '@/domain/entities/EditorTool';
 import { useI18n } from 'vue-i18n';
 
 interface UseNoteEditorOptions {
+  /**
+   * Null for new note, id for reading existing note
+   */
+  noteId: MaybeRefOrGetter<NoteId | null>;
+
   /**
    * Tools used in the note
    */
@@ -82,6 +89,19 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
    * concurrent loadToolsScripts invocations.
    */
   let currentLoadId = 0;
+
+  /**
+   * Reset editor state when the note changes
+   * Prevents showing the editor with stale tools or content
+   * from a previously opened note
+   */
+  watch(
+    () => toValue(options.noteId),
+    () => {
+      isEditorReady.value = false;
+    },
+    { immediate: true }
+  );
 
   /**
    * Combine note and user tools

--- a/src/application/services/useNoteEditor.ts
+++ b/src/application/services/useNoteEditor.ts
@@ -99,7 +99,6 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
 
   /**
    * Reset the editor when the note changes.
-
    * Exception — new note save: the route switches from null to createdId
    * for the same note, so the editor must NOT be recreated
    * (avoids blinking and losing the cursor).

--- a/src/presentation/pages/HistoryVersion.vue
+++ b/src/presentation/pages/HistoryVersion.vue
@@ -83,6 +83,7 @@ const { noteTitle, save } = useNote({
 const canEdit = ref(false);
 
 const { isEditorReady, editorConfig } = useNoteEditor({
+  noteId,
   noteTools: historyTools,
   isDraftResolver: () => false,
   noteContentResolver: () => historyContent.value,
@@ -104,7 +105,7 @@ async function useThisVersion() {
     const editorElement = editor.value ? editor.value.element : null;
 
     if (historyContent.value !== undefined) {
-      await save(historyContent.value, undefined);
+      await save(historyContent.value, undefined, props.noteId);
       /**
        * In case if we do not have note id, we can change its cover, and we need successful data for cover
        * We need to do it after saving in case of note creation

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -217,6 +217,8 @@ const verticalMenuItems = computed<VerticalMenuItem>(() => {
 watch(
   () => props.id,
   () => {
+    isEditorReady.value = false;
+
     /** If new child note is created, refresh editor with empty data */
     if (props.id === null) {
       useHead({

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -176,7 +176,7 @@ async function noteChanged(data: NoteContent): Promise<void> {
         paddingTop: '100px',
       });
     }
-    if (updatedNoteCover !== null && noteIdAtCallTime !== null) {
+    if (updatedNoteCover !== null && noteIdAtCallTime !== null && noteIdAtCallTime === props.id) {
       await updateCover(noteIdAtCallTime as NoteId, updatedNoteCover);
     }
   }

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -54,7 +54,6 @@
           <Editor
             v-if="isEditorReady"
             ref="editor"
-            :key="id || 'new'"
             v-bind="editorConfig"
             @change="noteChanged"
           />
@@ -127,6 +126,7 @@ function redirectToNoteSettings(): void {
 const { updateCover } = useNoteSettings();
 
 const { isEditorReady, editorConfig } = useNoteEditor({
+  noteId,
   noteTools,
   isDraftResolver: () => noteId.value === null,
   noteContentResolver: () => note.value?.content,
@@ -217,8 +217,6 @@ const verticalMenuItems = computed<VerticalMenuItem>(() => {
 watch(
   () => props.id,
   () => {
-    isEditorReady.value = false;
-
     /** If new child note is created, refresh editor with empty data */
     if (props.id === null) {
       useHead({

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -99,7 +99,7 @@ const props = defineProps<{
 
 const noteId = toRef(props, 'id');
 
-const { note, noteTools, save, noteTitle, canEdit, noteParents, noteHierarchy } = useNote({
+const { note, noteTools, save, noteTitle, canEdit, noteParents, noteHierarchy, getLastCreatedNoteId } = useNote({
   id: noteId,
 });
 
@@ -131,6 +131,7 @@ const { isEditorReady, editorConfig } = useNoteEditor({
   isDraftResolver: () => noteId.value === null,
   noteContentResolver: () => note.value?.content,
   canEdit,
+  getLastCreatedNoteId,
 });
 
 /**

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -68,7 +68,7 @@ import { computed, ref, toRef, watch } from 'vue';
 import { Button, Editor, PageBlock, VerticalMenu, type VerticalMenuItem } from '@codexteam/ui/vue';
 import useNote from '@/application/services/useNote';
 import { useRoute, useRouter } from 'vue-router';
-import { NoteContent } from '@/domain/entities/Note';
+import { NoteContent, type NoteId } from '@/domain/entities/Note';
 import { useHead } from 'unhead';
 import { useI18n } from 'vue-i18n';
 import { makeElementScreenshot } from '@/infrastructure/utils/screenshot';
@@ -153,7 +153,13 @@ async function noteChanged(data: NoteContent): Promise<void> {
   const editorElement = editor.value ? editor.value.element : null;
 
   if (!isEmpty) {
-    await save(data, props.parentId);
+    /**
+     * Capture the current note id at the time of the call
+     * to avoid race conditions when fast switching between notes
+     */
+    const noteIdAtCallTime = props.id;
+
+    await save(data, props.parentId, noteIdAtCallTime);
     /**
      * In case if we do not have note id, we can change its cover, and we need successful data for cover
      * We need to do it after saving in case of note creation
@@ -169,8 +175,8 @@ async function noteChanged(data: NoteContent): Promise<void> {
         paddingTop: '100px',
       });
     }
-    if (updatedNoteCover !== null && props.id !== null) {
-      await updateCover(props.id, updatedNoteCover);
+    if (updatedNoteCover !== null && noteIdAtCallTime !== null) {
+      await updateCover(noteIdAtCallTime as NoteId, updatedNoteCover);
     }
   }
 }

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -54,6 +54,7 @@
           <Editor
             v-if="isEditorReady"
             ref="editor"
+            :key="id || 'new'"
             v-bind="editorConfig"
             @change="noteChanged"
           />


### PR DESCRIPTION
## Problem

When switching between notes, the previously opened note's content could be applied to the newly opened note. Two root causes:

1. The previous note's editor stayed mounted while the new note loaded, so its handlers remained alive and could write the old content into the new note.
2. An in-flight `save()` used the id of the currently open note at completion time, so it wrote the old content into whatever note was open then.

## Solution

**1-st Fix: destroy the old editor on note change.** `useNoteEditor` now watches `noteId` and resets `isEditorReady` on every change. Since the `<Editor>` is rendered with `v-if="isEditorReady"`, the previous editor is unmounted/destroyed and a fresh one is mounted only after the new note's data and tools are ready. A live old editor can no longer save into the new note.

**2-nd Fix: bind each save to the note it was started for.** `noteChanged()` captures the note id at save start and passes it to `save()`, so an in-flight save always targets the correct note. Cached content (`lastUpdateContent`) and the note cover are only updated when the current note still matches the saved note, preventing stale data from leaking between notes.

## Key changes

- **`useNote.ts`** — `save()` now takes the captured note id and uses it for the update; cached content is only stored when the current note hasn't changed. Removed the now-unneeded `isNoteSaving` flag and the related draft-save skip logic.
- **`useNoteEditor.ts`** — added a `noteId` option and reset the editor state when the note changes.
- **`Note.vue`** — captures the note id at save time and passes it through; the cover is only updated when the captured id still matches the current note.