### PR TITLE
fix(chart): shared Y scale, tooltip overflow, and hover stacking

### DIFF
--- a/@codexteam/ui/dev/pages/components/Chart.vue
+++ b/@codexteam/ui/dev/pages/components/Chart.vue
@@ -65,13 +65,6 @@
         Static series legend under the chart: color dot + <code>label</code> for each line.
         Off by default so existing layouts stay the same.
       </p>
-      <div class="chart-props__control">
-        <span class="chart-props__control-label">Try it:</span>
-        <Switch
-          v-model="legendEnabled"
-          :value="legendEnabled"
-        />
-      </div>
     </div>
   </div>
 
@@ -87,6 +80,11 @@
         :is-disabled="false"
         :items="paletteColorItems"
       />
+      <span class="chart-props__control-label">legend:</span>
+      <Switch
+        v-model="legendEnabled"
+        :value="legendEnabled"
+      />
     </div>
     <div class="chart-example__showcase">
       <Chart
@@ -98,14 +96,56 @@
   </div>
 
   <Heading :level="3">
-    Multiple Lines
+    Shared scale
   </Heading>
+  <p class="chart-example-note">
+    Both series hit <code>50</code> on the same tick. They must sit on one horizontal line.
+  </p>
   <div class="chart-example">
+    <div class="chart-example__showcase">
+      <Chart
+        :lines="sharedScaleData"
+        :detalization="currentDetalization"
+        :legend="true"
+      />
+    </div>
+  </div>
+
+  <Heading :level="3">
+    Single spike
+  </Heading>
+  <p class="chart-example-note">
+    One non-zero point among zeros — should still show as a marker.
+  </p>
+  <div class="chart-example">
+    <div class="chart-example__showcase">
+      <Chart
+        :lines="spikeData"
+        :detalization="currentDetalization"
+        :legend="true"
+      />
+    </div>
+  </div>
+
+  <Heading :level="3">
+    Stacked
+  </Heading>
+  <p class="chart-example-note">
+    Many-series on top (tooltip can overlap the chart below). Some ticks have only one or two non-zero series.
+  </p>
+  <div class="chart-example chart-example--stack">
+    <div class="chart-example__showcase">
+      <Chart
+        :lines="paletteSeriesData"
+        :detalization="currentDetalization"
+        :legend="true"
+      />
+    </div>
     <div class="chart-example__showcase">
       <Chart
         :lines="multipleLinesData"
         :detalization="currentDetalization"
-        :legend="legendEnabled"
+        :legend="true"
       />
     </div>
   </div>
@@ -121,7 +161,7 @@
       <Chart
         :lines="paletteSeriesData"
         :detalization="currentDetalization"
-        :legend="legendEnabled"
+        :legend="true"
       />
     </div>
   </div>
@@ -137,7 +177,7 @@
       <Chart
         :lines="[hexLineData]"
         :detalization="currentDetalization"
-        :legend="legendEnabled"
+        :legend="true"
       />
     </div>
   </div>
@@ -225,9 +265,9 @@ const detalizationSelected = ref<DefaultItem>({
 });
 
 /**
- * Toggle static series legend in the preview
+ * Legend toggle for the Single Line preview
  */
-const legendEnabled = ref(true);
+const legendEnabled = ref(false);
 
 /**
  * Available detalization options for the Select component
@@ -338,16 +378,80 @@ const multipleLinesData = computed<ChartLine[]>(() => {
 });
 
 /**
+ * Two ranges, same count on one tick — must share Y
+ */
+const sharedScaleData = computed<ChartLine[]>(() => {
+  const timestamps = demoTimestamps.value;
+  const mid = Math.floor(timestamps.length / 2);
+
+  return [
+    {
+      label: 'wide',
+      color: ChartLineColor.Red,
+      data: timestamps.map((timestamp, index) => ({
+        timestamp,
+        count: index === mid ? 50 : 180,
+      })),
+    },
+    {
+      label: 'narrow',
+      color: ChartLineColor.Blue,
+      data: timestamps.map((timestamp, index) => ({
+        timestamp,
+        count: index === mid ? 50 : 20,
+      })),
+    },
+  ];
+});
+
+/**
+ * One event among zeros
+ */
+const spikeData = computed<ChartLine[]>(() => {
+  const timestamps = demoTimestamps.value;
+  const mid = Math.floor(timestamps.length / 2);
+
+  return [
+    {
+      label: 'incident',
+      color: ChartLineColor.Orange,
+      data: timestamps.map((timestamp, index) => ({
+        timestamp,
+        count: index === mid ? 90 : 0,
+      })),
+    },
+  ];
+});
+
+/**
+ * Long labels to check tooltip ellipsis
+ */
+const longPreviewLabels: Partial<Record<ChartLineColor, string>> = {
+  [ChartLineColor.Red]: 'accepted-events-from-the-ingestion-pipeline',
+  [ChartLineColor.LightGrey]: 'rate-limited-requests-waiting-in-queue',
+};
+
+/**
  * All hardcoded palette tokens stacked for comparison
  */
 const paletteSeriesData = computed<ChartLine[]>(() => {
   const timestamps = demoTimestamps.value;
   const bases = [150, 130, 110, 95, 80, 70, 55, 40, 25];
 
-  return paletteTokens.map((color, index) => ({
-    label: color,
-    data: generateData(timestamps, bases[index] ?? 50),
+  return paletteTokens.map((color, seriesIndex) => ({
+    label: longPreviewLabels[color] ?? color,
     color,
+    data: timestamps.map((timestamp, tick) => {
+      const activeSeries = (tick % 7) + 1;
+      const count = seriesIndex < activeSeries
+        ? Math.floor(Math.random() * (bases[seriesIndex] ?? 50)) + 10
+        : 0;
+
+      return {
+        timestamp,
+        count,
+      };
+    }),
   }));
 });
 </script>
@@ -437,6 +541,10 @@ const paletteSeriesData = computed<ChartLine[]>(() => {
 
   &--tall {
     padding-bottom: 240px;
+  }
+
+  &--stack {
+    gap: var(--spacing-m);
   }
 }
 </style>

--- a/@codexteam/ui/package.json
+++ b/@codexteam/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexteam/ui",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "sideEffects": [
     "*.css",

--- a/@codexteam/ui/src/vue/components/chart/Chart.vue
+++ b/@codexteam/ui/src/vue/components/chart/Chart.vue
@@ -1,5 +1,10 @@
 <template>
-  <div :class="$style.chart">
+  <div
+    :class="[
+      $style.chart,
+      hoveredIndex >= 0 && $style['chart--raised']
+    ]"
+  >
     <div
       ref="plot"
       :class="$style.chart__plot"
@@ -49,7 +54,6 @@
           :key="`cursor-${preparedLine.line.label}-${index}`"
         >
           <div
-            v-if="!preparedLine.allZeros"
             :style="{
               transform: `translateY(${getLinePointerTop(preparedLine)}px)`,
               backgroundColor: getCursorColor(preparedLine.line)
@@ -72,25 +76,33 @@
             {{ formatTimestamp(firstLineData[hoveredIndex].timestamp * 1000) }}
           </div>
           <div
-            v-for="item in tooltipLines"
-            :key="`tooltip-line-${item.prepared.index}`"
-            :class="$style['chart__pointer-tooltip-number']"
+            :class="$style['chart__pointer-tooltip-list']"
+            @wheel.stop
           >
-            <span
-              :class="$style['chart__pointer-tooltip-dot']"
-              :style="{ backgroundColor: getCursorColor(item.prepared.line) }"
-            />
-            <span :class="$style['chart__pointer-tooltip-metrics']">
+            <div
+              v-for="item in tooltipLines"
+              :key="`tooltip-line-${item.prepared.index}`"
+              :class="$style['chart__pointer-tooltip-number']"
+            >
               <span
-                :key="`tooltip-value-${item.prepared.index}-${item.value}`"
-                :class="$style['chart__pointer-tooltip-value']"
-              >
-                {{ formatSpacedNumber(item.value) }}
+                :class="$style['chart__pointer-tooltip-dot']"
+                :style="{ backgroundColor: getCursorColor(item.prepared.line) }"
+              />
+              <span :class="$style['chart__pointer-tooltip-metrics']">
+                <span
+                  :key="`tooltip-value-${item.prepared.index}-${item.value}`"
+                  :class="$style['chart__pointer-tooltip-value']"
+                >
+                  {{ formatSpacedNumber(item.value) }}
+                </span>
+                <span
+                  :class="$style['chart__pointer-tooltip-label']"
+                  :title="item.prepared.line.label"
+                >
+                  {{ item.prepared.line.label }}
+                </span>
               </span>
-              <span :class="$style['chart__pointer-tooltip-label']">
-                {{ item.prepared.line.label }}
-              </span>
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -103,6 +115,7 @@
         v-for="(preparedLine, index) in preparedLines"
         :key="`legend-${preparedLine.line.label}-${index}`"
         :class="$style['chart__legend-item']"
+        :title="preparedLine.line.label"
       >
         <span
           :class="$style['chart__legend-dot']"
@@ -123,13 +136,12 @@ import ChartLine from './ChartLine.vue';
 import { throttle } from '../../utils';
 
 /**
- * Prepared line with precomputed min/max/allZeros
+ * Prepared line with precomputed min/max
  */
 interface PreparedLine {
   line: ChartLineInterface;
   min: number;
   max: number;
-  allZeros: boolean;
   index: number;
 }
 
@@ -206,38 +218,39 @@ const tooltipPinned = ref(false);
 const chartLeft = ref(0);
 
 /**
- * Precomputed line data with min/max/allZeros
- * This avoids recalculating O(n_data) on every render/mousemove
+ * Shared Y scale so identical counts sit on the same height
  */
-const preparedLines = computed((): PreparedLine[] => {
-  return props.lines.map((line, index) => {
-    let min = Infinity;
-    let max = 0;
-    let allZeros = true;
+const chartValueScale = computed((): { min: number; max: number } => {
+  let max = 0;
 
+  for (const line of props.lines) {
     for (const item of line.data ?? []) {
-      const v = item.count ?? 0;
+      const value = item.count ?? 0;
 
-      if (v < min) {
-        min = v;
-      }
-      if (v > max) {
-        max = v;
-      }
-      if (v !== 0) {
-        allZeros = false;
+      if (value > max) {
+        max = value;
       }
     }
+  }
 
-    const safeMin = min === Infinity ? 0 : min;
-    const safeMax = max * 1.5;
+  return {
+    min: 0,
+    max: max > 0 ? max * 1.5 : 1,
+  };
+});
 
-    return { line,
-      min: safeMin,
-      max: safeMax,
-      allZeros,
-      index };
-  });
+/**
+ * Precomputed line data with shared min/max
+ */
+const preparedLines = computed((): PreparedLine[] => {
+  const { min, max } = chartValueScale.value;
+
+  return props.lines.map((line, index) => ({
+    line,
+    min,
+    max,
+    index,
+  }));
 });
 
 /**
@@ -375,13 +388,17 @@ const tooltipLines = computed((): Array<{
   }
 
   return preparedLines.value
-    .filter(prepared => !prepared.allZeros)
     .map(prepared => ({
       prepared,
       value: getLineValueAtHoveredIndex(prepared.line, hoveredIndex.value),
     }))
     .sort((a, b) => b.value - a.value);
 });
+
+/**
+ * Tooltip width cap, same as CSS max-width
+ */
+const TOOLTIP_MAX_WIDTH_PX = 220;
 
 /**
  * Tooltip min-width based on the longest visible series row
@@ -394,20 +411,15 @@ const tooltipMinWidth = computed((): number => {
   const dateLabel = formatTimestamp(firstLineData.value[hoveredIndex.value].timestamp * 1000);
   let maxLength = dateLabel.length;
 
-  for (const prepared of preparedLines.value) {
-    if (prepared.allZeros) {
-      continue;
-    }
-
-    const value = formatSpacedNumber(getLineValueAtHoveredIndex(prepared.line, hoveredIndex.value));
-    const row = `${value} ${prepared.line.label}`;
+  for (const item of tooltipLines.value) {
+    const row = `${formatSpacedNumber(item.value)} ${item.prepared.line.label}`;
 
     if (row.length > maxLength) {
       maxLength = row.length;
     }
   }
 
-  return maxLength * 5.6 + 28;
+  return Math.min(TOOLTIP_MAX_WIDTH_PX, maxLength * 5.6 + 28);
 });
 
 /**
@@ -665,7 +677,7 @@ onBeforeUnmount(() => {
 
 .chart {
   position: relative;
-  isolation: isolate;
+  z-index: 0;
   display: flex;
   flex-direction: column;
   overflow: visible;
@@ -674,6 +686,10 @@ onBeforeUnmount(() => {
 
   --legend-height: var(--spacing-xxl);
   --legend-block-padding: var(--spacing-s);
+}
+
+.chart--raised {
+  z-index: var(--z-popover);
 }
 
 .chart__plot {
@@ -751,6 +767,7 @@ onBeforeUnmount(() => {
   gap: var(--spacing-xs);
   padding-block: var(--tooltip-block-padding);
   padding-inline: var(--spacing-xs);
+  max-width: 220px;
   color: var(--base--text);
   @apply --text-ui-small;
   white-space: nowrap;
@@ -793,15 +810,41 @@ onBeforeUnmount(() => {
   text-align: center;
 }
 
+.chart__pointer-tooltip-list {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: var(--spacing-xs);
+  line-height: 1;
+
+  &:has(> :nth-child(6)) {
+    max-height: calc(5lh + 4 * var(--spacing-xs));
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-width: thin;
+
+    &::-webkit-scrollbar {
+      width: var(--spacing-xxs);
+    }
+  }
+}
+
 .chart__pointer-tooltip-number {
   display: flex;
   align-items: center;
+  flex-shrink: 0;
+  min-width: 0;
   gap: var(--spacing-xs);
+  height: 1lh;
+  line-height: 1;
 }
 
 .chart__pointer-tooltip-metrics {
   display: flex;
   align-items: baseline;
+  min-width: 0;
+  flex: 1;
   gap: var(--spacing-xs);
 }
 
@@ -811,12 +854,16 @@ onBeforeUnmount(() => {
 }
 
 .chart__pointer-tooltip-value {
+  flex-shrink: 0;
   color: var(--base--text);
   animation: tooltip-value-in 500ms ease;
 }
 
 .chart__pointer-tooltip-label {
+  min-width: 0;
+  overflow: hidden;
   color: var(--base--text-secondary);
+  text-overflow: ellipsis;
 }
 
 .chart__legend-dot,


### PR DESCRIPTION
## Summary
- Shared Y scale across series so the same `count` sits on the same height; isolated spikes get a marker.
- Tooltip hides zero rows, caps at ~5 lines with overflow scroll (no visible scrollbar), and stays put while the cursor is over it.
- Hovered chart raises `z-index` so the tooltip is not covered by a chart below.
<img width="382" height="320" alt="изображение" src="https://github.com/user-attachments/assets/0e8dc6ee-a1a5-4188-9920-9d75ab1a3cf0" />
