### PR TITLE
feat: add configuration for imageTool

### DIFF
--- a/src/application/services/useNoteEditor.ts
+++ b/src/application/services/useNoteEditor.ts
@@ -2,8 +2,8 @@ import { type Ref, computed, ref, toValue, watch } from 'vue';
 import { useAppState } from './useAppState';
 import type EditorTool from '@/domain/entities/EditorTool';
 import { type NoteContent } from '@/domain/entities/Note';
-import { editorToolsService } from '@/domain';
-import type { EditorjsToolsConfig } from '@/domain/entities/EditorTool';
+import { editorToolsService, noteSettingsService } from '@/domain';
+import type { EditorjsConfigTool, EditorjsToolsConfig } from '@/domain/entities/EditorTool';
 import { useI18n } from 'vue-i18n';
 
 interface UseNoteEditorOptions {
@@ -21,6 +21,12 @@ interface UseNoteEditorOptions {
    * Flag indicating that user can edit the note
    */
   canEdit: Ref<boolean>;
+
+  /**
+   * Note id to build image upload endpoint
+   * Null for new notes
+   */
+  noteId: Ref<string | null>;
 }
 
 interface UseNoteEditorComposableState {
@@ -131,13 +137,67 @@ export const useNoteEditor = function useNoteEditor(options: UseNoteEditorOption
 
     return Object.fromEntries(
       loadedToolsWithoutParagraph
-        .map(toolClassAndInfo => [
-          toolClassAndInfo.tool.name,
-          {
+        .map((toolClassAndInfo) => {
+          const toolConfig: { class: EditorjsConfigTool; inlineToolbar: boolean; config?: Record<string, unknown> } = {
             class: toolClassAndInfo.class,
             inlineToolbar: true,
-          },
-        ])
+          };
+
+          /**
+           * Add image tool config with a custom uploader
+           * that uses the authorized note attachment upload method
+           */
+          if (toolClassAndInfo.tool.name === 'image') {
+            const noteId = toValue(options.noteId);
+
+            if (noteId !== null) {
+              toolConfig.config = {
+                /**
+                 * The image tool internally accesses `this.config.endpoints.byFile`
+                 * when a file is selected, even when a custom uploader is provided
+                 * Provide an empty endpoints object to prevent a TypeError
+                 */
+                endpoints: {
+                  byFile: '',
+                },
+                features: {
+                  caption: 'optional',
+                },
+                uploader: {
+                  /**
+                   * Uploads file using the existing authorized repository method
+                   * @param file - file selected in the editor
+                   */
+                  uploadByFile: async (file: File): Promise<{ success: 1; file: { url: string } }> => {
+                    const url = await noteSettingsService.uploadImage(noteId, file);
+
+                    return {
+                      success: 1,
+                      file: {
+                        url,
+                      },
+                    };
+                  },
+                  /**
+                   * When a user pastes an image URL, use it as-is
+                   * without uploading the image to the server
+                   * @param url - image URL pasted by the user
+                   */
+                  uploadByUrl: (url: string): Promise<{ success: 1; file: { url: string } }> => {
+                    return Promise.resolve({
+                      success: 1,
+                      file: {
+                        url,
+                      },
+                    });
+                  },
+                },
+              };
+            }
+          }
+
+          return [toolClassAndInfo.tool.name, toolConfig];
+        })
     );
   }
 

--- a/src/domain/entities/EditorTool.ts
+++ b/src/domain/entities/EditorTool.ts
@@ -81,7 +81,7 @@ export type EditorjsConfigTool = ToolSettings | ToolConstructable;
 /**
  * Editor.js tools config — map of tool name to its class and inline toolbar flag
  */
-export type EditorjsToolsConfig = Record<string, { class: EditorjsConfigTool; inlineToolbar: boolean }>;
+export type EditorjsToolsConfig = Record<string, { class: EditorjsConfigTool; inlineToolbar: boolean; config?: Record<string, unknown> }>;
 
 /**
  * Editor tool info alogn with its plugin's class ready to use

--- a/src/domain/noteAttachmentUploader.repository.interface.ts
+++ b/src/domain/noteAttachmentUploader.repository.interface.ts
@@ -19,4 +19,12 @@ export default interface NoteAttachmentUploaderRepositoryInterface {
    * @returns file binary data
    */
   load: (noteId: Note['id'], key: string) => Promise<Blob>;
+
+  /**
+   * Build a URL to load the note attachment by key
+   * @param noteId - identifier for note to get attachment
+   * @param key - file key on server side
+   * @returns URL of the attachment
+   */
+  getFileUrl: (noteId: Note['id'], key: string) => string;
 }

--- a/src/domain/noteSettings.service.ts
+++ b/src/domain/noteSettings.service.ts
@@ -81,6 +81,19 @@ export default class NoteSettingsService {
   }
 
   /**
+   * Upload an image to be used in the note editor
+   * Uses the authorized transport via noteAttachmentRepository
+   * @param id - note id
+   * @param data - image binary data
+   * @returns URL of the uploaded image that can be rendered in the editor
+   */
+  public async uploadImage(id: NoteId, data: Blob): Promise<string> {
+    const key = await this.noteAttachmentRepository.upload(id, data);
+
+    return this.noteAttachmentRepository.getFileUrl(id, key);
+  }
+
+  /**
    * Revoke invitation hash
    * @param id - Note id
    * @returns updated note settings

--- a/src/infrastructure/noteAttachmentUploader.repository.ts
+++ b/src/infrastructure/noteAttachmentUploader.repository.ts
@@ -53,4 +53,14 @@ export default class NoteAttachmentUploaderRepository implements NoteAttachmentU
   public async load(noteId: Note['id'], key: string): Promise<Blob> {
     return await this.transport.getBlob(`/upload/${noteId}/${key}`);
   }
+
+  /**
+   * Build a URL to load the note attachment by key
+   * @param noteId - identifier for note to get attachment
+   * @param key - file key on server side
+   * @returns URL of the attachment
+   */
+  public getFileUrl(noteId: Note['id'], key: string): string {
+    return this.transport.getBaseUrl() + `/upload/${noteId}/${key}`;
+  }
 }

--- a/src/infrastructure/transport/fetch.transport.ts
+++ b/src/infrastructure/transport/fetch.transport.ts
@@ -33,6 +33,13 @@ export default class FetchTransport {
   ) {}
 
   /**
+   * Returns the base URL of the transport
+   */
+  public getBaseUrl(): string {
+    return this.baseUrl;
+  }
+
+  /**
    * Gets specific resource
    * @template Response - Response data type
    * @param endpoint - API endpoint

--- a/src/presentation/pages/HistoryVersion.vue
+++ b/src/presentation/pages/HistoryVersion.vue
@@ -86,6 +86,7 @@ const { isEditorReady, editorConfig } = useNoteEditor({
   noteTools: historyTools,
   noteContentResolver: () => historyContent.value,
   canEdit,
+  noteId,
 });
 
 /**

--- a/src/presentation/pages/Note.vue
+++ b/src/presentation/pages/Note.vue
@@ -129,6 +129,7 @@ const { isEditorReady, editorConfig } = useNoteEditor({
   noteTools,
   noteContentResolver: () => note.value?.content,
   canEdit,
+  noteId,
 });
 
 /**


### PR DESCRIPTION
## Summary

Added Editor.js __image tool__ (https://github.com/editor-js/image) configuration with a custom uploader that integrates with the existing authorized note attachment upload pipeline.

## Details

- __`useNoteEditor.ts`__ — Added a `noteId` option to the composable. When the image tool is loaded and a `noteId` is available, the tool is configured with a custom `uploadByFile` uploader that calls `noteSettingsService.uploadImage()` (which uses the authorized `noteAttachmentRepository`), and an `uploadByUrl` handler that accepts pasted URLs as-is.

- __`noteSettings.service.ts`__ — Added `uploadImage(id, data)` method that uploads a image via the attachment repository and returns the file URL.

- __`noteAttachmentUploader.repository.ts`__ — Implemented `getFileUrl(noteId, key)` to build a direct URL to a stored attachment.

- __`noteAttachmentUploader.repository.interface.ts`__ — Added `getFileUrl` to the repository interface.

- __`fetch.transport.ts`__ — Added `getBaseUrl()` method to expose the transport's base URL.

- __`EditorTool.ts`__ — Extended `EditorjsToolsConfig` type to support an optional `config` field per tool.

- __`Note.vue` & `HistoryVersion.vue`__ — Pass `noteId` to the `useNoteEditor` composable.

Also check other related PR: [Disabling authorization for GET image requests](https://github.com/codex-team/notes.api/pull/305)


